### PR TITLE
Fix Typo

### DIFF
--- a/_docs/api.md
+++ b/_docs/api.md
@@ -1040,7 +1040,7 @@ Response on success: [204]
 
 Body of response: empty.
 
-## <a name="session_delete"></a>Delete an interview session
+## <a name="session_retrieve"></a>Retrieve an interview session
 
 Description: Retrieves a stored file
 


### PR DESCRIPTION
The section above is "Delete an interview session", but this section should be "Retrieve an interview session".