### PR TITLE
Add autoreconf

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -214,6 +214,7 @@ The latest version of the [Perl Audio Converter] can be installed by doing:
 sudo apt-get -q -y remove pacpl
 git clone git://git.code.sf.net/p/pacpl/code pacpl-code 
 cd pacpl-code
+autoreconf
 ./configure
 make
 sudo make install


### PR DESCRIPTION
When manually installing on Ubuntu 16.04, I had to run autoreconf in order to compile configure.