### PR TITLE
Fix to Match Example

### DIFF
--- a/_docs/template.md
+++ b/_docs/template.md
@@ -19,7 +19,7 @@ section is to describe the `template` and `table` blocks.
 
 # <a name="template"></a>The `template` block
 
-A `template` block allows you assign text to a variable and then
+A `template` block allows you to assign text to a variable and then
 re-use the text by referring to a variable.
 
 {% include side-by-side.html demo="template" %}
@@ -65,9 +65,9 @@ separate [Markdown] file.
 The file [`disclaimer.md`] is a simple [Markdown] file containing the
 disclaimer from the previous example.
 
-The `source file` is assumed to refer to a file in the "templates"
+The `content file` is assumed to refer to a file in the "templates"
 folder of the same package as the interview source, unless a specific
-package name is indicated.  (e.g., `source file:`
+package name is indicated.  (e.g., `content file:`
 [`docassemble.demo:data/templates/hello_template.md`])
 
 In the example above, the sample interview is in the file


### PR DESCRIPTION
The example uses `content file` but documentation had `source file`.