### PR TITLE
Add a tag to Screening Users

### DIFF
--- a/_docs/users.md
+++ b/_docs/users.md
@@ -124,7 +124,7 @@ with the [`appname`] directive.  If the [`appname`] is
 >
 > -- MyDocassemble 
 
-# Screening users
+# <a name="screen_users">Screening users</a>
 
 Interviews can behave differently depending on whether the user is
 logged in, or the role of the logged-in user.


### PR DESCRIPTION
I was going to refer someone on slack to Screening Users, and there wasn't an HTML tag for it yet.