### PR TITLE
Fix subdoc images, shapes, styles, footnotes, etc

### DIFF
--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 import re
 import os
+from copy import deepcopy
 from six import string_types, text_type, PY2
 from docxtpl import DocxTemplate, R, InlineImage, RichText, Listing, Document, Subdoc
 from docx.shared import Mm, Inches, Pt
 import docx.opc.constants
+from docxcompose.composer import Composer # For fixing up images, etc when including docx files within templates
+from docx.oxml.section import CT_SectPr # For figuring out if an element is a section or not
 from docassemble.base.functions import server, this_thread, package_template_filename, get_config
 import docassemble.base.filter
 from xml.sax.saxutils import escape as html_escape
@@ -89,6 +92,32 @@ class InlineHyperlink(object):
     def __str__(self):
         return self._insert_link()
 
+def fix_subdoc(masterdoc, subdoc):
+    """Fix the images, styles, references, shapes, etc of a subdoc"""
+    composer = Composer(masterdoc) # Using docxcompose
+    composer.reset_reference_mapping()
+
+    # This is the same as the docxcompose function, except it doesn't copy the elements over.
+    # Copying the elements over is done by returning the subdoc XML in this function.
+    # Both sd.subdocx and the master template file are changed with these functions.
+    composer._create_style_id_mapping(subdoc)
+    for element in subdoc.element.body:
+        if isinstance(element, CT_SectPr):
+            continue
+        composer.add_referenced_parts(subdoc.part, masterdoc.part, element)
+        composer.add_styles(subdoc, element)
+        composer.add_numberings(subdoc, element)
+        composer.restart_first_numbering(subdoc, element)
+        composer.add_images(subdoc, element)
+        composer.add_shapes(subdoc, element)
+        composer.add_footnotes(subdoc, element)
+        composer.remove_header_and_footer_references(subdoc, element)
+
+    composer.add_styles_from_other_parts(subdoc)
+    composer.renumber_bookmarks()
+    composer.renumber_docpr_ids()
+    composer.fix_section_types(subdoc)
+
 def include_docx_template(template_file, **kwargs):
     """Include the contents of one docx file inside another docx file."""
     if this_thread.evaluation_context is None:
@@ -100,6 +129,17 @@ def include_docx_template(template_file, **kwargs):
     sd = this_thread.misc['docx_template'].new_subdoc()
     sd.subdocx = Document(template_path)
     sd.subdocx._part = sd.docx._part
+
+    # We need to keep a copy of the subdocs so we can fix up the master template in the end (in parse.py)
+	# Given we're half way through processing the template, we can't fix the master template here
+	# we have to do it in post
+    if 'docx_subdocs' not in this_thread.misc:
+        this_thread.misc['docx_subdocs'] = []
+    this_thread.misc['docx_subdocs'].append(deepcopy(sd.subdocx))
+
+	# Fix the subdocs before they are included in the template
+    fix_subdoc(this_thread.misc['docx_template'], sd.subdocx)
+
     first_paragraph = sd.subdocx.paragraphs[0]
     for key, val in kwargs.items():
         if hasattr(val, 'instanceName'):
@@ -110,6 +150,7 @@ def include_docx_template(template_file, **kwargs):
     if 'docx_include_count' not in this_thread.misc:
         this_thread.misc['docx_include_count'] = 0
     this_thread.misc['docx_include_count'] += 1
+
     return sd
 
 def add_to_rt(tpl, rt, parsed):

--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -128,7 +128,6 @@ def include_docx_template(template_file, **kwargs):
         template_path = package_template_filename(template_file, package=this_thread.current_package)
     sd = this_thread.misc['docx_template'].new_subdoc()
     sd.subdocx = Document(template_path)
-    sd.subdocx._part = sd.docx._part
 
     # We need to keep a copy of the subdocs so we can fix up the master template in the end (in parse.py)
 	# Given we're half way through processing the template, we can't fix the master template here

--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import re
 import os
-from copy import deepcopy
 from six import string_types, text_type, PY2
 from docxtpl import DocxTemplate, R, InlineImage, RichText, Listing, Document, Subdoc
 from docx.shared import Mm, Inches, Pt
 import docx.opc.constants
-from docxcompose.composer import Composer # For fixing up images, etc when including docx files within templates
-from docx.oxml.section import CT_SectPr # For figuring out if an element is a section or not
 from docassemble.base.functions import server, this_thread, package_template_filename, get_config
 import docassemble.base.filter
 from xml.sax.saxutils import escape as html_escape
@@ -92,32 +89,6 @@ class InlineHyperlink(object):
     def __str__(self):
         return self._insert_link()
 
-def fix_subdoc(masterdoc, subdoc):
-    """Fix the images, styles, references, shapes, etc of a subdoc"""
-    composer = Composer(masterdoc) # Using docxcompose
-    composer.reset_reference_mapping()
-
-    # This is the same as the docxcompose function, except it doesn't copy the elements over.
-    # Copying the elements over is done by returning the subdoc XML in this function.
-    # Both sd.subdocx and the master template file are changed with these functions.
-    composer._create_style_id_mapping(subdoc)
-    for element in subdoc.element.body:
-        if isinstance(element, CT_SectPr):
-            continue
-        composer.add_referenced_parts(subdoc.part, masterdoc.part, element)
-        composer.add_styles(subdoc, element)
-        composer.add_numberings(subdoc, element)
-        composer.restart_first_numbering(subdoc, element)
-        composer.add_images(subdoc, element)
-        composer.add_shapes(subdoc, element)
-        composer.add_footnotes(subdoc, element)
-        composer.remove_header_and_footer_references(subdoc, element)
-
-    composer.add_styles_from_other_parts(subdoc)
-    composer.renumber_bookmarks()
-    composer.renumber_docpr_ids()
-    composer.fix_section_types(subdoc)
-
 def include_docx_template(template_file, **kwargs):
     """Include the contents of one docx file inside another docx file."""
     if this_thread.evaluation_context is None:
@@ -129,17 +100,6 @@ def include_docx_template(template_file, **kwargs):
     sd = this_thread.misc['docx_template'].new_subdoc()
     sd.subdocx = Document(template_path)
     sd.subdocx._part = sd.docx._part
-
-    # We need to keep a copy of the subdocs so we can fix up the master template in the end (in parse.py)
-	# Given we're half way through processing the template, we can't fix the master template here
-	# we have to do it in post
-    if 'docx_subdocs' not in this_thread.misc:
-        this_thread.misc['docx_subdocs'] = []
-    this_thread.misc['docx_subdocs'].append(deepcopy(sd.subdocx))
-
-	# Fix the subdocs before they are included in the template
-    fix_subdoc(this_thread.misc['docx_template'], sd.subdocx)
-
     first_paragraph = sd.subdocx.paragraphs[0]
     for key, val in kwargs.items():
         if hasattr(val, 'instanceName'):
@@ -150,7 +110,6 @@ def include_docx_template(template_file, **kwargs):
     if 'docx_include_count' not in this_thread.misc:
         this_thread.misc['docx_include_count'] = 0
     this_thread.misc['docx_include_count'] += 1
-
     return sd
 
 def add_to_rt(tpl, rt, parsed):

--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 import re
 import os
+from copy import deepcopy
 from six import string_types, text_type, PY2
 from docxtpl import DocxTemplate, R, InlineImage, RichText, Listing, Document, Subdoc
 from docx.shared import Mm, Inches, Pt
 import docx.opc.constants
+from docxcompose.composer import Composer # For fixing up images, etc when including docx files within templates
+from docx.oxml.section import CT_SectPr # For figuring out if an element is a section or not
 from docassemble.base.functions import server, this_thread, package_template_filename, get_config
 import docassemble.base.filter
 from xml.sax.saxutils import escape as html_escape
@@ -89,6 +92,32 @@ class InlineHyperlink(object):
     def __str__(self):
         return self._insert_link()
 
+def fix_subdoc(masterdoc, subdoc):
+    """Fix the images, styles, references, shapes, etc of a subdoc"""
+    composer = Composer(masterdoc) # Using docxcompose
+    composer.reset_reference_mapping()
+
+    # This is the same as the docxcompose function, except it doesn't copy the elements over.
+    # Copying the elements over is done by returning the subdoc XML in this function.
+    # Both sd.subdocx and the master template file are changed with these functions.
+    composer._create_style_id_mapping(subdoc)
+    for element in subdoc.element.body:
+        if isinstance(element, CT_SectPr):
+            continue
+        composer.add_referenced_parts(subdoc.part, masterdoc.part, element)
+        composer.add_styles(subdoc, element)
+        composer.add_numberings(subdoc, element)
+        composer.restart_first_numbering(subdoc, element)
+        composer.add_images(subdoc, element)
+        composer.add_shapes(subdoc, element)
+        composer.add_footnotes(subdoc, element)
+        composer.remove_header_and_footer_references(subdoc, element)
+
+    composer.add_styles_from_other_parts(subdoc)
+    composer.renumber_bookmarks()
+    composer.renumber_docpr_ids()
+    composer.fix_section_types(subdoc)
+
 def include_docx_template(template_file, **kwargs):
     """Include the contents of one docx file inside another docx file."""
     if this_thread.evaluation_context is None:
@@ -99,7 +128,17 @@ def include_docx_template(template_file, **kwargs):
         template_path = package_template_filename(template_file, package=this_thread.current_package)
     sd = this_thread.misc['docx_template'].new_subdoc()
     sd.subdocx = Document(template_path)
-    sd.subdocx._part = sd.docx._part
+
+    # We need to keep a copy of the subdocs so we can fix up the master template in the end (in parse.py)
+    # Given we're half way through processing the template, we can't fix the master template here
+    # we have to do it in post
+    if 'docx_subdocs' not in this_thread.misc:
+        this_thread.misc['docx_subdocs'] = []
+    this_thread.misc['docx_subdocs'].append(deepcopy(sd.subdocx))
+
+    # Fix the subdocs before they are included in the template
+    fix_subdoc(this_thread.misc['docx_template'], sd.subdocx)
+
     first_paragraph = sd.subdocx.paragraphs[0]
     for key, val in kwargs.items():
         if hasattr(val, 'instanceName'):

--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -128,6 +128,7 @@ def include_docx_template(template_file, **kwargs):
         template_path = package_template_filename(template_file, package=this_thread.current_package)
     sd = this_thread.misc['docx_template'].new_subdoc()
     sd.subdocx = Document(template_path)
+    sd.subdocx._part = sd.docx._part
 
     # We need to keep a copy of the subdocs so we can fix up the master template in the end (in parse.py)
 	# Given we're half way through processing the template, we can't fix the master template here

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -758,7 +758,7 @@ class TextObject(object):
     def __init__(self, x, question=None):
         self.original_text = x
         self.other_lang = dict()
-        if question is not None and question.interview.source.translating and re.search(r'[^\s0-9]', self.original_text) and not re.search(r'\<%doc\>\s*do not translate', self.original_text, re.IGNORECASE) and self.original_text != 'no label':
+        if question is not None and question.interview.source.translating and isinstance(x, string_types) and re.search(r'[^\s0-9]', self.original_text) and not re.search(r'\<%doc\>\s*do not translate', self.original_text, re.IGNORECASE) and self.original_text != 'no label':
             if not hasattr(question, 'translations'):
                 question.translations = list()
             if self.original_text not in question.translations:
@@ -775,7 +775,7 @@ class TextObject(object):
             self.uses_mako = True
         else:
             self.uses_mako = False
-        if question is not None and len(question.interview.translations):
+        if question is not None and len(question.interview.translations) and isinstance(x, string_types):
             if self.original_text in question.interview.translation_dict:
                 if question.language == '*':
                     self.language = docassemble.base.functions.server.default_language
@@ -2583,7 +2583,7 @@ class Question:
                                     field_info['selections'] = dict()
                                 else:
                                     field_info['choicetype'] = 'manual'
-                                    field_info['selections'] = dict(values=process_selections_manual(field[key]))
+                                    field_info['selections'] = dict(values=self.process_selections_manual(field[key]))
                                     if 'datatype' not in field:
                                         auto_determine_type(field_info)
                                     for item in field_info['selections']['values']:
@@ -3678,10 +3678,13 @@ class Question:
                     if common_var is None:
                         common_var = the_saveas
                         continue
+                    mismatch = False
                     for char_index in range(len(common_var)):
                         if the_saveas[char_index] != common_var[char_index]:
+                            mismatch = True
                             break
-                    common_var = common_var[0:char_index]
+                    if mismatch:
+                        common_var = common_var[0:char_index]
                 common_var = re.sub(r'[^\]]*$', '', common_var)
                 m = re.search(r'^(.*)\[([ijklmn])\]$', common_var)
                 if not m:
@@ -4179,7 +4182,7 @@ class Question:
                         result_dict['image'] = value
                         continue
                     if key == 'help':
-                        result_dict['help'] = TextObject(value)
+                        result_dict['help'] = TextObject(value, question=self)
                         continue
                     if key == 'default':
                         result_dict['default'] = value
@@ -4190,10 +4193,10 @@ class Question:
                         result_dict['compute'] = compile(value, '<expression>', 'eval')
                         self.find_fields_in(value)
                     else:
-                        result_dict['label'] = TextObject(key)
-                        result_dict['key'] = TextObject(value)
+                        result_dict['label'] = TextObject(key, question=self)
+                        result_dict['key'] = TextObject(value, question=self)
                 elif isinstance(value, dict):
-                    result_dict['label'] = TextObject(key)
+                    result_dict['label'] = TextObject(key, question=self)
                     self.embeds = True
                     if PY3:
                         result_dict['key'] = Question(value, self.interview, register_target=register_target, source=self.from_source, package=self.package, source_code=codecs.decode(bytearray(yaml.safe_dump(value, default_flow_style=False, default_style = '|', allow_unicode=True), encoding='utf-8'), 'utf-8'))
@@ -4202,19 +4205,19 @@ class Question:
                 elif isinstance(value, string_types):
                     if value in ('exit', 'logout', 'exit_logout', 'leave') and 'url' in the_dict:
                         self.embeds = True
-                        result_dict['label'] = TextObject(key)
+                        result_dict['label'] = TextObject(key, question=self)
                         result_dict['key'] = Question({'command': value, 'url': the_dict['url']}, self.interview, register_target=register_target, source=self.from_source, package=self.package)
                     elif value in ('continue', 'restart', 'refresh', 'signin', 'register', 'exit', 'logout', 'exit_logout', 'leave', 'new_session'):
                         self.embeds = True
-                        result_dict['label'] = TextObject(key)
+                        result_dict['label'] = TextObject(key, question=self)
                         result_dict['key'] = Question({'command': value}, self.interview, register_target=register_target, source=self.from_source, package=self.package)
                     elif key == 'url':
                         pass
                     else:
-                        result_dict['label'] = TextObject(key)
+                        result_dict['label'] = TextObject(key, question=self)
                         result_dict['key'] = value
                 elif isinstance(value, bool):
-                    result_dict['label'] = TextObject(key)
+                    result_dict['label'] = TextObject(key, question=self)
                     result_dict['key'] = value
                 else:
                     raise DAError("Unknown data type in parse_fields:" + str(type(value)) + ".  " + self.idebug(the_list))
@@ -4313,23 +4316,16 @@ class Question:
                         docassemble.base.functions.set_context('docx', template=result['template'])
                         try:
                             the_template = result['template']
-                            while True: # Rerender if there's a subdoc using include_docx_template
+                            while True:
                                 old_count = docassemble.base.functions.this_thread.misc.get('docx_include_count', 0)
                                 the_template.render(result['field_data'], jinja_env=custom_jinja_env())
                                 if docassemble.base.functions.this_thread.misc.get('docx_include_count', 0) > old_count and old_count < 10:
-                                    # There's another template included
                                     new_template_file = tempfile.NamedTemporaryFile(prefix="datemp", mode="wb", suffix=".docx", delete=False)
-                                    the_template.save(new_template_file.name) # Save and refresh the template
+                                    the_template.save(new_template_file.name)
                                     the_template = docassemble.base.file_docx.DocxTemplate(new_template_file.name)
                                     docassemble.base.functions.this_thread.misc['docx_template'] = the_template
                                 else:
                                     break
-							# Copy over images, etc from subdoc to master template
-                            subdocs = docassemble.base.functions.this_thread.misc.get('docx_subdocs', []) # Get the subdoc file list
-                            the_template_docx = the_template.docx
-                            for subdoc in subdocs:
-                                docassemble.base.file_docx.fix_subdoc(the_template_docx, subdoc)
-                            
                         except TemplateError as the_error:
                             if (not hasattr(the_error, 'filename')) or the_error.filename is None:
                                 the_error.filename = os.path.basename(attachment['options']['docx_template_file'].path(the_user_dict=the_user_dict))
@@ -4697,6 +4693,55 @@ class Question:
                 #logmessage("output was:\n" + repr(result['content'][doc_format]))
         if old_language is not None:
             docassemble.base.functions.set_language(old_language)
+        return(result)
+    def process_selections_manual(self, data):
+        result = []
+        if isinstance(data, list):
+            for entry in data:
+                if isinstance(entry, dict):
+                    the_item = dict()
+                    for key in entry:
+                        if len(entry) > 1:
+                            if key in ['default', 'help', 'image']:
+                                continue
+                            if 'key' in entry and 'label' in entry and key != 'key':
+                                continue
+                            if 'default' in entry:
+                                the_item['default'] = entry['default']
+                            if 'help' in entry:
+                                the_item['help'] = TextObject(entry['help'], question=self)
+                            if 'image' in entry:
+                                if entry['image'].__class__.__name__ == 'DAFile':
+                                    entry['image'].retrieve()
+                                    if entry['image'].mimetype is not None and entry['image'].mimetype.startswith('image'):
+                                        the_item['image'] = dict(type='url', value=entry['image'].url_for())
+                                elif entry['image'].__class__.__name__ == 'DAFileList':
+                                    entry['image'][0].retrieve()
+                                    if entry['image'][0].mimetype is not None and entry['image'][0].mimetype.startswith('image'):
+                                        the_item['image'] = dict(type='url', value=entry['image'][0].url_for())
+                                elif entry['image'].__class__.__name__ == 'DAStaticFile':
+                                    the_item['image'] = dict(type='url', value=entry['image'].url_for())
+                                else:
+                                    the_item['image'] = dict(type='decoration', value=entry['image'])
+                            if 'key' in entry and 'label' in entry:
+                                the_item['key'] = TextObject(entry['key'], question=self)
+                                the_item['label'] = TextObject(entry['label'], question=self)
+                                result.append(the_item)
+                                continue
+                        the_item['key'] = TextObject(entry[key], question=self)
+                        the_item['label'] = TextObject(key, question=self)
+                        result.append(the_item)
+                if isinstance(entry, list):
+                    result.append(dict(key=TextObject(entry[0], question=self), label=TextObject(entry[1], question=self)))
+                elif isinstance(entry, string_types):
+                    result.append(dict(key=TextObject(entry, question=self), label=TextObject(entry, question=self)))
+                elif isinstance(entry, (int, float, bool, NoneType)):
+                    result.append(dict(key=TextObject(text_type(entry), question=self), label=TextObject(text_type(entry), question=self)))
+        elif isinstance(data, dict):
+            for key, value in sorted(data.items(), key=operator.itemgetter(1)):
+                result.append(dict(key=TextObject(value, question=self), label=TextObject(key, question=self)))
+        else:
+            raise DAError("Unknown data type in manual choices selection: " + re.sub(r'[<>]', '', repr(data)))
         return(result)
 
 def emoji_matcher_insert(obj):
@@ -6232,56 +6277,6 @@ def process_selections(data, manual=False, exclude=None):
                     logmessage("process_selections: non-label passed as label in dictionary")
     else:
         raise DAError("Unknown data type in choices selection: " + re.sub(r'[<>]', '', repr(data)))
-    return(result)
-
-def process_selections_manual(data):
-    result = []
-    if isinstance(data, list):
-        for entry in data:
-            if isinstance(entry, dict):
-                the_item = dict()
-                for key in entry:
-                    if len(entry) > 1:
-                        if key in ['default', 'help', 'image']:
-                            continue
-                        if 'key' in entry and 'label' in entry and key != 'key':
-                            continue
-                        if 'default' in entry:
-                            the_item['default'] = entry['default']
-                        if 'help' in entry:
-                            the_item['help'] = TextObject(entry['help'])
-                        if 'image' in entry:
-                            if entry['image'].__class__.__name__ == 'DAFile':
-                                entry['image'].retrieve()
-                                if entry['image'].mimetype is not None and entry['image'].mimetype.startswith('image'):
-                                    the_item['image'] = dict(type='url', value=entry['image'].url_for())
-                            elif entry['image'].__class__.__name__ == 'DAFileList':
-                                entry['image'][0].retrieve()
-                                if entry['image'][0].mimetype is not None and entry['image'][0].mimetype.startswith('image'):
-                                    the_item['image'] = dict(type='url', value=entry['image'][0].url_for())
-                            elif entry['image'].__class__.__name__ == 'DAStaticFile':
-                                the_item['image'] = dict(type='url', value=entry['image'].url_for())
-                            else:
-                                the_item['image'] = dict(type='decoration', value=entry['image'])
-                        if 'key' in entry and 'label' in entry:
-                            the_item['key'] = TextObject(entry['key'])
-                            the_item['label'] = TextObject(entry['label'])
-                            result.append(the_item)
-                            continue
-                    the_item['key'] = TextObject(entry[key])
-                    the_item['label'] = TextObject(key)
-                    result.append(the_item)
-            if isinstance(entry, list):
-                result.append(dict(key=TextObject(entry[0]), label=TextObject(entry[1])))
-            elif isinstance(entry, string_types):
-                result.append(dict(key=TextObject(entry), label=TextObject(entry)))
-            elif isinstance(entry, (int, float, bool, NoneType)):
-                result.append(dict(key=TextObject(text_type(entry)), label=TextObject(text_type(entry))))
-    elif isinstance(data, dict):
-        for key, value in sorted(data.items(), key=operator.itemgetter(1)):
-            result.append(dict(key=TextObject(value), label=TextObject(key)))
-    else:
-        raise DAError("Unknown data type in manual choices selection: " + re.sub(r'[<>]', '', repr(data)))
     return(result)
 
 def extract_missing_name(the_error):

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -758,7 +758,7 @@ class TextObject(object):
     def __init__(self, x, question=None):
         self.original_text = x
         self.other_lang = dict()
-        if question is not None and question.interview.source.translating and isinstance(x, string_types) and re.search(r'[^\s0-9]', self.original_text) and not re.search(r'\<%doc\>\s*do not translate', self.original_text, re.IGNORECASE) and self.original_text != 'no label':
+        if question is not None and question.interview.source.translating and re.search(r'[^\s0-9]', self.original_text) and not re.search(r'\<%doc\>\s*do not translate', self.original_text, re.IGNORECASE) and self.original_text != 'no label':
             if not hasattr(question, 'translations'):
                 question.translations = list()
             if self.original_text not in question.translations:
@@ -775,7 +775,7 @@ class TextObject(object):
             self.uses_mako = True
         else:
             self.uses_mako = False
-        if question is not None and len(question.interview.translations) and isinstance(x, string_types):
+        if question is not None and len(question.interview.translations):
             if self.original_text in question.interview.translation_dict:
                 if question.language == '*':
                     self.language = docassemble.base.functions.server.default_language
@@ -2583,7 +2583,7 @@ class Question:
                                     field_info['selections'] = dict()
                                 else:
                                     field_info['choicetype'] = 'manual'
-                                    field_info['selections'] = dict(values=self.process_selections_manual(field[key]))
+                                    field_info['selections'] = dict(values=process_selections_manual(field[key]))
                                     if 'datatype' not in field:
                                         auto_determine_type(field_info)
                                     for item in field_info['selections']['values']:
@@ -3678,13 +3678,10 @@ class Question:
                     if common_var is None:
                         common_var = the_saveas
                         continue
-                    mismatch = False
                     for char_index in range(len(common_var)):
                         if the_saveas[char_index] != common_var[char_index]:
-                            mismatch = True
                             break
-                    if mismatch:
-                        common_var = common_var[0:char_index]
+                    common_var = common_var[0:char_index]
                 common_var = re.sub(r'[^\]]*$', '', common_var)
                 m = re.search(r'^(.*)\[([ijklmn])\]$', common_var)
                 if not m:
@@ -4182,7 +4179,7 @@ class Question:
                         result_dict['image'] = value
                         continue
                     if key == 'help':
-                        result_dict['help'] = TextObject(value, question=self)
+                        result_dict['help'] = TextObject(value)
                         continue
                     if key == 'default':
                         result_dict['default'] = value
@@ -4193,10 +4190,10 @@ class Question:
                         result_dict['compute'] = compile(value, '<expression>', 'eval')
                         self.find_fields_in(value)
                     else:
-                        result_dict['label'] = TextObject(key, question=self)
-                        result_dict['key'] = TextObject(value, question=self)
+                        result_dict['label'] = TextObject(key)
+                        result_dict['key'] = TextObject(value)
                 elif isinstance(value, dict):
-                    result_dict['label'] = TextObject(key, question=self)
+                    result_dict['label'] = TextObject(key)
                     self.embeds = True
                     if PY3:
                         result_dict['key'] = Question(value, self.interview, register_target=register_target, source=self.from_source, package=self.package, source_code=codecs.decode(bytearray(yaml.safe_dump(value, default_flow_style=False, default_style = '|', allow_unicode=True), encoding='utf-8'), 'utf-8'))
@@ -4205,19 +4202,19 @@ class Question:
                 elif isinstance(value, string_types):
                     if value in ('exit', 'logout', 'exit_logout', 'leave') and 'url' in the_dict:
                         self.embeds = True
-                        result_dict['label'] = TextObject(key, question=self)
+                        result_dict['label'] = TextObject(key)
                         result_dict['key'] = Question({'command': value, 'url': the_dict['url']}, self.interview, register_target=register_target, source=self.from_source, package=self.package)
                     elif value in ('continue', 'restart', 'refresh', 'signin', 'register', 'exit', 'logout', 'exit_logout', 'leave', 'new_session'):
                         self.embeds = True
-                        result_dict['label'] = TextObject(key, question=self)
+                        result_dict['label'] = TextObject(key)
                         result_dict['key'] = Question({'command': value}, self.interview, register_target=register_target, source=self.from_source, package=self.package)
                     elif key == 'url':
                         pass
                     else:
-                        result_dict['label'] = TextObject(key, question=self)
+                        result_dict['label'] = TextObject(key)
                         result_dict['key'] = value
                 elif isinstance(value, bool):
-                    result_dict['label'] = TextObject(key, question=self)
+                    result_dict['label'] = TextObject(key)
                     result_dict['key'] = value
                 else:
                     raise DAError("Unknown data type in parse_fields:" + str(type(value)) + ".  " + self.idebug(the_list))
@@ -4316,16 +4313,23 @@ class Question:
                         docassemble.base.functions.set_context('docx', template=result['template'])
                         try:
                             the_template = result['template']
-                            while True:
+                            while True: # Rerender if there's a subdoc using include_docx_template
                                 old_count = docassemble.base.functions.this_thread.misc.get('docx_include_count', 0)
                                 the_template.render(result['field_data'], jinja_env=custom_jinja_env())
                                 if docassemble.base.functions.this_thread.misc.get('docx_include_count', 0) > old_count and old_count < 10:
+                                    # There's another template included
                                     new_template_file = tempfile.NamedTemporaryFile(prefix="datemp", mode="wb", suffix=".docx", delete=False)
-                                    the_template.save(new_template_file.name)
+                                    the_template.save(new_template_file.name) # Save and refresh the template
                                     the_template = docassemble.base.file_docx.DocxTemplate(new_template_file.name)
                                     docassemble.base.functions.this_thread.misc['docx_template'] = the_template
                                 else:
                                     break
+							# Copy over images, etc from subdoc to master template
+                            subdocs = docassemble.base.functions.this_thread.misc.get('docx_subdocs', []) # Get the subdoc file list
+                            the_template_docx = the_template.docx
+                            for subdoc in subdocs:
+                                docassemble.base.file_docx.fix_subdoc(the_template_docx, subdoc)
+                            
                         except TemplateError as the_error:
                             if (not hasattr(the_error, 'filename')) or the_error.filename is None:
                                 the_error.filename = os.path.basename(attachment['options']['docx_template_file'].path(the_user_dict=the_user_dict))
@@ -4693,55 +4697,6 @@ class Question:
                 #logmessage("output was:\n" + repr(result['content'][doc_format]))
         if old_language is not None:
             docassemble.base.functions.set_language(old_language)
-        return(result)
-    def process_selections_manual(self, data):
-        result = []
-        if isinstance(data, list):
-            for entry in data:
-                if isinstance(entry, dict):
-                    the_item = dict()
-                    for key in entry:
-                        if len(entry) > 1:
-                            if key in ['default', 'help', 'image']:
-                                continue
-                            if 'key' in entry and 'label' in entry and key != 'key':
-                                continue
-                            if 'default' in entry:
-                                the_item['default'] = entry['default']
-                            if 'help' in entry:
-                                the_item['help'] = TextObject(entry['help'], question=self)
-                            if 'image' in entry:
-                                if entry['image'].__class__.__name__ == 'DAFile':
-                                    entry['image'].retrieve()
-                                    if entry['image'].mimetype is not None and entry['image'].mimetype.startswith('image'):
-                                        the_item['image'] = dict(type='url', value=entry['image'].url_for())
-                                elif entry['image'].__class__.__name__ == 'DAFileList':
-                                    entry['image'][0].retrieve()
-                                    if entry['image'][0].mimetype is not None and entry['image'][0].mimetype.startswith('image'):
-                                        the_item['image'] = dict(type='url', value=entry['image'][0].url_for())
-                                elif entry['image'].__class__.__name__ == 'DAStaticFile':
-                                    the_item['image'] = dict(type='url', value=entry['image'].url_for())
-                                else:
-                                    the_item['image'] = dict(type='decoration', value=entry['image'])
-                            if 'key' in entry and 'label' in entry:
-                                the_item['key'] = TextObject(entry['key'], question=self)
-                                the_item['label'] = TextObject(entry['label'], question=self)
-                                result.append(the_item)
-                                continue
-                        the_item['key'] = TextObject(entry[key], question=self)
-                        the_item['label'] = TextObject(key, question=self)
-                        result.append(the_item)
-                if isinstance(entry, list):
-                    result.append(dict(key=TextObject(entry[0], question=self), label=TextObject(entry[1], question=self)))
-                elif isinstance(entry, string_types):
-                    result.append(dict(key=TextObject(entry, question=self), label=TextObject(entry, question=self)))
-                elif isinstance(entry, (int, float, bool, NoneType)):
-                    result.append(dict(key=TextObject(text_type(entry), question=self), label=TextObject(text_type(entry), question=self)))
-        elif isinstance(data, dict):
-            for key, value in sorted(data.items(), key=operator.itemgetter(1)):
-                result.append(dict(key=TextObject(value, question=self), label=TextObject(key, question=self)))
-        else:
-            raise DAError("Unknown data type in manual choices selection: " + re.sub(r'[<>]', '', repr(data)))
         return(result)
 
 def emoji_matcher_insert(obj):
@@ -6277,6 +6232,56 @@ def process_selections(data, manual=False, exclude=None):
                     logmessage("process_selections: non-label passed as label in dictionary")
     else:
         raise DAError("Unknown data type in choices selection: " + re.sub(r'[<>]', '', repr(data)))
+    return(result)
+
+def process_selections_manual(data):
+    result = []
+    if isinstance(data, list):
+        for entry in data:
+            if isinstance(entry, dict):
+                the_item = dict()
+                for key in entry:
+                    if len(entry) > 1:
+                        if key in ['default', 'help', 'image']:
+                            continue
+                        if 'key' in entry and 'label' in entry and key != 'key':
+                            continue
+                        if 'default' in entry:
+                            the_item['default'] = entry['default']
+                        if 'help' in entry:
+                            the_item['help'] = TextObject(entry['help'])
+                        if 'image' in entry:
+                            if entry['image'].__class__.__name__ == 'DAFile':
+                                entry['image'].retrieve()
+                                if entry['image'].mimetype is not None and entry['image'].mimetype.startswith('image'):
+                                    the_item['image'] = dict(type='url', value=entry['image'].url_for())
+                            elif entry['image'].__class__.__name__ == 'DAFileList':
+                                entry['image'][0].retrieve()
+                                if entry['image'][0].mimetype is not None and entry['image'][0].mimetype.startswith('image'):
+                                    the_item['image'] = dict(type='url', value=entry['image'][0].url_for())
+                            elif entry['image'].__class__.__name__ == 'DAStaticFile':
+                                the_item['image'] = dict(type='url', value=entry['image'].url_for())
+                            else:
+                                the_item['image'] = dict(type='decoration', value=entry['image'])
+                        if 'key' in entry and 'label' in entry:
+                            the_item['key'] = TextObject(entry['key'])
+                            the_item['label'] = TextObject(entry['label'])
+                            result.append(the_item)
+                            continue
+                    the_item['key'] = TextObject(entry[key])
+                    the_item['label'] = TextObject(key)
+                    result.append(the_item)
+            if isinstance(entry, list):
+                result.append(dict(key=TextObject(entry[0]), label=TextObject(entry[1])))
+            elif isinstance(entry, string_types):
+                result.append(dict(key=TextObject(entry), label=TextObject(entry)))
+            elif isinstance(entry, (int, float, bool, NoneType)):
+                result.append(dict(key=TextObject(text_type(entry)), label=TextObject(text_type(entry))))
+    elif isinstance(data, dict):
+        for key, value in sorted(data.items(), key=operator.itemgetter(1)):
+            result.append(dict(key=TextObject(value), label=TextObject(key)))
+    else:
+        raise DAError("Unknown data type in manual choices selection: " + re.sub(r'[<>]', '', repr(data)))
     return(result)
 
 def extract_missing_name(the_error):


### PR DESCRIPTION
This commit uses docxcompose (a new dependency) to fix up images, shapes, etc from subdocs that are included using include_docx_template. The images and shapes should now show up properly without issue and styles should be properly transferred across.

I've done testing for a bunch of different cases, but there is the worry that this could break things that currently work. That said, it should enable much more modular templating, allowing things like a standard signature which is included in all of the generated documents.