### PR TITLE
add cron to configuration options list

### DIFF
--- a/_docs/docker.md
+++ b/_docs/docker.md
@@ -603,6 +603,7 @@ to server).
   * `rabbitmq`: The [Docker] container will run the central [RabbitMQ] service.
   * `log`: The [Docker] container will run the central log aggregation service.
   * `mail`: The [Docker] container will run [Exim] in order to accept [e-mails].
+  * `cron`: The [Docker] container will run the Cron service to schedule tasks. 
 * <a name="SERVERHOSTNAME"></a>`SERVERHOSTNAME`: In a
   [multi-server arrangement], all **docassemble** application servers
   need to be able to communicate with each other using port 9001 (the


### PR DESCRIPTION
List of containerroles omitted `cron` in the configuration options. This adds it back in.