### PR TITLE
Add more information on Github private repos.

### DIFF
--- a/_docs/development.md
+++ b/_docs/development.md
@@ -418,25 +418,25 @@ GitHub repository, you can still use the [Playground].
 
 Create the repository on [GitHub], and mark it as private.
 
-Then go to your user settings and go to the "Personal access tokens"
+Then go to your "Developer settings" and go to the "Personal access tokens"
 tab.  Click "Generate new token."  You can set the "Token description"
 to whatever you like (e.g. "docassemble playground access").  Check
 the "repo" checkbox, so that all of the capabilities under "repo" are
 selected.  Then click "Generate token."  Copy the "personal access
 token" and keep it in a safe place.  If your token is
-`e8cc02bec7061de98ba4851263638d7483f63d41`, your GitHub username is
+`personalaccesstoken`, your GitHub username is
 `johnsmith`, and your package is called
 `docassemble-missouri-familylaw`, then you can access your private
 repository at this URL:
 
 {% highlight text %}
-https://e8cc02bec7061de98ba4851263638d7483f63d41:x-oauth-basic@github.com/johnsmith/docassemble-missouri-familylaw
+https://johnsmith:personalaccesstoken@github.com/johnsmith/docassemble-missouri-familylaw
 {% endhighlight %}
 
 For example, you could do:
 
 {% highlight bash %}
-git clone https://e8cc02bec7061de98ba4851263638d7483f63d41:x-oauth-basic@github.com/johnsmith/docassemble-missouri-familylaw
+git clone https://johnsmith:personalaccesstoken@github.com/johnsmith/docassemble-missouri-familylaw
 {% endhighlight %}
 
 Within docassemble, you can go to "Package Management" and enter this

--- a/_docs/packages.md
+++ b/_docs/packages.md
@@ -309,6 +309,21 @@ such package actually exists.)
 
 ![GitHub Install]({{ site.baseurl }}/img/github-install.png){: .maybe-full-width }
 
+If you want to install a *private* [Github] repository, you will need a Personal 
+Access Token to access it. If you do not have already have a token,
+you will have to generate a new one under the "Personal access tokens" tab under
+your "Developer settings". Your token must enable all of the 
+capabilities under "repo". You can do this by checking the "repo" checkbox when you
+generate your token.
+
+If your token is `personalaccesstoken`, your GitHub username is
+`johnsmith`, and your package is called `docassemble-missouri-familylaw`, the 
+"GitHub URL" you enter in step 3 is as follows:
+
+{% highlight text %}
+https://johnsmith:personalaccesstoken@github.com/johnsmith/docassemble-missouri-familylaw
+{% endhighlight %}
+
 ## <a name="zip_install"></a>Installing through a .zip file
 
 You can also install [Python] packages from ZIP files.  For example,


### PR DESCRIPTION
* Add install private repos information in package management as well
* Change format of private repo url to a more user friendly notation. (Both URL formats work IRL) 
* More beginner friendly instruction on constructing private repo URL
* Slightly more specific instructions on generating a personal token