### PR TITLE
letsencrypt-auto syntax

### DIFF
--- a/Docker/cron/docassemble-cron-daily.sh
+++ b/Docker/cron/docassemble-cron-daily.sh
@@ -39,14 +39,14 @@ if [[ $CONTAINERROLE =~ .*:(all|web):.* ]]; then
 		if [ "${DAWEBSERVER:-nginx}" = "apache" ]; then
 		    supervisorctl --serverurl http://localhost:9001 stop apache2
 		    cd "${DA_ROOT}/letsencrypt"
-		    ./letsencrypt-auto renew --apache --cert-name "${DAHOSTNAME}"
+		    ./letsencrypt-auto certonly --apache --cert-name "${DAHOSTNAME}"
 		    /etc/init.d/apache2 stop
 		    supervisorctl --serverurl http://localhost:9001 start apache2
 		fi
 		if [ "${DAWEBSERVER:-nginx}" = "nginx" ]; then
 		    supervisorctl --serverurl http://localhost:9001 stop nginx
 		    cd "${DA_ROOT}/letsencrypt"
-		    ./letsencrypt-auto renew --nginx --cert-name "${DAHOSTNAME}"
+		    ./letsencrypt-auto certonly --nginx --cert-name "${DAHOSTNAME}"
 		    nginx -s stop &> /dev/null
 		    supervisorctl --serverurl http://localhost:9001 start nginx
 		fi


### PR DESCRIPTION
Lets Encrypt was not renewing and was logging the following error:

"Currently, the renew verb is capable of either renewing all installed certificates that are due to be renewed or renewing a single certificate specified by its name. If you would like to renew specific certificates by their domains, use the certonly command instead. The renew verb may provide other options for selecting certificates to renew in the future."