### PR TITLE
Change to french translation for 'Clear'

### DIFF
--- a/docassemble_base/docassemble/base/data/sources/fr-words.yml
+++ b/docassemble_base/docassemble/base/data/sources/fr-words.yml
@@ -72,7 +72,7 @@
   "Checkboxes:": "Cases à cocher:"
   "Choices:": "Les choix:"
   "Classes": "Des classes"
-  "Clear": "Nettoyer"
+  "Clear": "Effacez"
   "Click here to confirm your e-mail": "Cliquez ici pour confirmer votre e-mail"
   "Click here to get help over the phone.": "Cliquez ici pour obtenir de l'aide par téléphone."
   "Click if you want the user to be able to call you.": "Cliquez si vous souhaitez que l'utilisateur puisse vous appeler."


### PR DESCRIPTION
A french user of ours pointed out that the translation for the 'Clear' button for signatures should be 'Effacez' and not 'Nettoyer'.