### PR TITLE
Enable markdown formatting in field-level help

### DIFF
--- a/docassemble_base/docassemble/base/standardformatter.py
+++ b/docassemble_base/docassemble/base/standardformatter.py
@@ -1012,7 +1012,7 @@ def as_html(status, url_for, debug, root, validation_rules, field_error, the_pro
                 else:
                     field_class += ' da-field-container-inputtype-dropdown'
             if field.number in status.helptexts:
-                helptext_start = '<a tabindex="0" class="daterm" data-container="body" data-toggle="popover" data-placement="bottom" data-content=' + noquote(status.helptexts[field.number]) + '>'
+                helptext_start = '<a tabindex="0" class="daterm" data-container="body" data-toggle="popover" data-placement="bottom" data-content=' + noquote(markdown_to_html(status.helptexts[field.number], trim=True)) + '>'
                 helptext_end = '&nbsp;<sup style="white-space: nowrap"><i class="fas fa-question-circle"></i></sup></a>'
             else:
                 helptext_start = ''


### PR DESCRIPTION
Both question-level and choice-level help sections can use markdown formatting. With this change, help sections on the field level  can use markdown formatting as well.