### PR TITLE
Remove get-pip.py from the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,6 @@ bash -c \
 && chmod ogu+r /usr/share/docassemble/config/config.yml.dist \
 && chmod 755 /etc/ssl/docassemble \
 && cd /tmp \
-&& wget https://bootstrap.pypa.io/get-pip.py \
-&& python get-pip.py \
-&& rm -f get-pip.py \
-&& pip install --upgrade virtualenv \
 && echo \"en_US.UTF-8 UTF-8\" >> /etc/locale.gen \
 && locale-gen \
 && update-locale"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ bash -c \
 "cd /tmp \
 && python3.8 -m venv --copies /usr/share/docassemble/local3.8 \
 && source /usr/share/docassemble/local3.8/bin/activate \
-&& pip3 install --upgrade pip==20.3.1 \
+&& pip3 install --upgrade pip==20.3.4 \
 && pip3 install --upgrade mod_wsgi==4.7.1 \
 && pip3 install --upgrade \
    3to2==1.1.1 \


### PR DESCRIPTION
It looks like pip 20.3.1 is installed elsewhere and `get-pip.py` is not necessary.