### PR TITLE
Feature adding key vault reference support within config file

### DIFF
--- a/docassemble_webapp/setup.py
+++ b/docassemble_webapp/setup.py
@@ -22,6 +22,8 @@ install_requires = [
     "azure-common==1.1.26",
     "azure-core==1.9.0",
     "azure-nspkg==3.0.2",
+    "azure-identity==1.5.0",
+    "azure-keyvault-secrets==4.2.0",
     "azure-storage-blob==12.6.0",
     "Babel==2.9.0",
     "bcrypt==3.2.0",


### PR DESCRIPTION
### Update:
I have added very basic support for Azure Key Vault secret reference strings embedded within the config file.

**Please consider reviewing the proposed changes and integrating them as you see fit.**

_Note: this update does not extend the managed identity to Azure Storage authentication, users will still need to provide the initial Azure Storage keys to access the configuration file. The managed identity is just currently enabled for Key Vault access - however the full managed identity authentication scenario using no stored keys end-to-end (including Azure Storage) could be achieved with additional small updates._

> #### Pre-requisites:
> 1. Whatever Azure service is running the Docassemble application (Virtual Machine, App Service, AKS) will need to have a system-assigned managed identity enabled (which will be needed in the next pre-requisite step).
![image](https://user-images.githubusercontent.com/49538256/108316082-3c30b400-7171-11eb-9f44-2a3aebe78c7f.png)
> 2. You need to create an Azure Key Vault, and add any secrets that you would like to reference in your Docassemble configuration file. (Such as db password, azure account key, or other sensitive credentials). The key vault will need to assign permissions to the managed identity you enabled to read its secrets.

#### Basic Functionality:
1. User must provide two additional configuration values under the 'Azure' configuration section:
   - `managed identity: True` 
   - `key vault name: keyvaultname`
   - ![image](https://user-images.githubusercontent.com/49538256/108315934-fe339000-7170-11eb-9994-cb87aada76b4.png)
2. When both of these settings are enabled the user can provide strings that follow the standard [Key Vault reference format](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#reference-syntax).
   - For example, your database information can now reference a secret name stored in your vault and look it up before connecting:
   - `"@Microsoft.KeyVault(SecretUri=https://mykeyvaultname.vault.azure.net/secrets/mydbsecretname/<version_guid>)"`
   - _Note: You must wrap these references in double quotes in the config or it will not be valid yaml!_
3. When the configuration file is loaded, the load function will attempt to do a regex replace calling out to the Key Vault to retrieve and replace the variables in memory with the secret values. No retrieved variables will be written back to the configuration file if they were retrieved from Key Vault.

Each time the configuration is loaded the app will need to authenticate, check its permissions to the vault and grab the secrets it needs. This locks down the permissions and exposure for critical secrets we may want to keep from being written to the config file in plain text or exposed in Azure Storage.