### PR TITLE
Don't throw error if there are no fields in PDF

### DIFF
--- a/docassemble_base/docassemble/base/core.py
+++ b/docassemble_base/docassemble/base/core.py
@@ -3504,7 +3504,10 @@ class DAFile(DAObject):
         """Returns a list of fields that exist in the PDF document"""
         results = list()
         import docassemble.base.pdftk
-        for item in docassemble.base.pdftk.read_fields(self.path()):
+        all_items = docassemble.base.pdftk.read_fields(self.path())
+        if all_items is None:
+            return None
+        for item in all_items:
             the_type = re.sub(r'[^/A-Za-z]', '', str(item[4]))
             if the_type == 'None':
                 the_type = None


### PR DESCRIPTION
Right now on HEAD, if you call `DAFile.get_pdf_fields()`on a PDF with no fields, you'll get a `'NoneType' object is not iterable` error (in full below). This is just happening because docassemble tries to immediately iterate over returned object, even if it's none.

This change just checks for and forwards the `None` object if it's present.

Can add any testes if necessary, I couldn't find where to add any. But a similar patch is working on our [Weaver interview](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/pull/251/files#diff-48c88c3fcd4d754a1b6bdd0e739d8ef79da95bb640718aef2afd712e989db71aR1070).  Currently trying to ensure this works on a docker image, but still in progress. 

----------------------------

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/webapp/server.py", line 7240, in index
    interview.assemble(user_dict, interview_status, old_user_dict, force_question=special_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 7735, in assemble
    raise the_error
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 7526, in assemble
    question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 8286, in askfor
    question_result = self.askfor(newMissingVariable, user_dict, old_user_dict, interview_status, variable_stack=variable_stack, questions_tried=questions_tried, seeking=seeking, follow_mc=follow_mc, recursion_depth=recursion_depth, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 8286, in askfor
    question_result = self.askfor(newMissingVariable, user_dict, old_user_dict, interview_status, variable_stack=variable_stack, questions_tried=questions_tried, seeking=seeking, follow_mc=follow_mc, recursion_depth=recursion_depth, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 8286, in askfor
    question_result = self.askfor(newMissingVariable, user_dict, old_user_dict, interview_status, variable_stack=variable_stack, questions_tried=questions_tried, seeking=seeking, follow_mc=follow_mc, recursion_depth=recursion_depth, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 8174, in askfor
    exec_with_trap(question, user_dict)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 8741, in exec_with_trap
    exec(the_question.compute, the_dict)
  File "<code block>", line 2, in <module>
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/core.py", line 3967, in get_pdf_fields
    return self.elements[0].get_pdf_fields()
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/core.py", line 3503, in get_pdf_fields
    for item in docassemble.base.pdftk.read_fields(self.path()):
TypeError: 'NoneType' object is not iterable
```