### PR TITLE
Show more information on ScannerErrors

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -7152,12 +7152,7 @@ class Interview:
                     document = yaml.safe_load(source_code)
                 except Exception as errMess:
                     self.success = False
-                    #sys.stderr.write("Error: " + str(source_code) + "\n")
-                    #str(source_code)
-                    try:
-                        raise DAError('Error reading YAML file ' + str(source.path) + '\n\nDocument source code was:\n\n---\n' + str(source_code) + '---\n\nError was:\n\n' + str(errMess))
-                    except:
-                        raise DAError('Error reading YAML file ' + str(source.path) + '\n\nDocument source code was:\n\n---\n' + str(source_code) + '---\n\nError was:\n\n' + str(errMess.__class__.__name__))
+                    raise DAError('Error reading YAML file ' + str(source.path) + '\n\nDocument source code was:\n\n---' + str(source_code) + '---\n\nError was:\n\n' + str(errMess))
                 if document is not None:
                     try:
                         question = Question(document, self, source=source, package=source_package, source_code=source_code)


### PR DESCRIPTION
At the moment, Scanner Errors show relatively little information about what caused them.
All you see is the block that the Scanner Error occurred in. This change shows the
original error message (which was being hidden in a try-except), which points you directly
to the line that the Scanner Error occurred.

It's not ideal for newer users still, and could use a more guided approach based on the error
("i.e. it looks like your indentation is wrong"), but this is a first step.