### PR TITLE
Default editable gherkin scripts

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -102,7 +102,7 @@ code: |
 """
 
 ok_mimetypes = {"application/javascript": "javascript", "text/x-python": "python", "application/json": "json", "text/css": "css", 'text/html': 'htmlmixed'}
-ok_extensions = {"yml": "yaml", "yaml": "yaml", "md": "markdown", "markdown": "markdown", 'py': "python", "json": "json", "css": "css", "html": "htmlmixed"}
+ok_extensions = {"yml": "yaml", "yaml": "yaml", "md": "markdown", "markdown": "markdown", 'py': "python", "json": "json", "css": "css", "html": "htmlmixed", "feature": "gherkin"}
 
 try:
     if 'editable mimetypes' in daconfig and isinstance(daconfig['editable mimetypes'], list):


### PR DESCRIPTION
Adds gherkin scripts as default editable, without having to change `editable extensions`.

Given that [the documentation](https://docassemble.org/docs/development.html#bdd) talks about using gherkin / `.feature` scripts, it makes sense for that extension to be editable as text in the playground. The only other type of file that uses `.feature` extension is [Visual Studio](https://extension.nirsoft.net/feature), which shouldn't really show up in DA projects, and even then it's still XML, so you won't accidentally flood the editor with binary and possibly corrupt things.