### PR TITLE
Strip ending '/'s off github URLs

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -14514,7 +14514,7 @@ def update_package():
                 flash("Error of type " + str(type(errMess)) + " processing upload: " + str(errMess), "error")
         else:
             if form.giturl.data:
-                giturl = form.giturl.data.strip()
+                giturl = form.giturl.data.strip().rstrip('/')
                 branch = form.gitbranch.data.strip()
                 if not branch:
                     branch = get_master_branch(giturl)
@@ -25071,7 +25071,7 @@ def api_package():
                 result = docassemble.webapp.worker.update_packages.delay(restart=False)
             return jsonify_task(result)
         if 'github_url' in post_data:
-            github_url = post_data['github_url']
+            github_url = post_data['github_url'].rstrip('/')
             branch = post_data.get('branch', None)
             if branch is None:
                 branch = get_master_branch(github_url)


### PR DESCRIPTION
Currently, if you pass a Github URL to the /updatepackage page, for example, `https://github.com/SuffolkLITLab/docassemble-ALDocument/`, the server will run:
```
pip install --no-cache-dir --quiet --prefix=/usr/share/docassemble/local3.8 --src=/tmp/tmp6w2i9cb2 --upgrade --log-file=/tmp/tmpmuy02yb5 git+https://github.com/SuffolkLITLab/docassemble-ALDocument/.git@main#egg=docassemble.ALDocument
```
adding `.git` directly to the end. The easy fix to this is to strip off the ending slash at input time.

I had some options here: either strip the `/` off the URLs directly after receiving them from the user, or right before installing them to the package database (in `install_git_package`). I went with the former, as the URLs are first checked with `user_can_edit_package`, which wouldn't recognize a URL with vs without an ending '/' as the same.

I left alone any github URL params that weren't directly installing (i.e. only cloning), as we aren't adding `.git` to the end of them. 

I can confirm this patch works on the /updatepackage page, but haven't used the API to make sure the fix replicates there as well.