### PR TITLE
Added a new example on max in dates, to be referenced in the docs

### DIFF
--- a/docassemble_base/docassemble/base/data/questions/examples/date-limit.yml
+++ b/docassemble_base/docassemble/base/data/questions/examples/date-limit.yml
@@ -1,0 +1,13 @@
+metadata:
+  title: Date
+  documentation: "https://docassemble.org/docs/fields.html#date"
+---
+question: What is your date of birth?
+fields:
+  - Your birthday: birthdate
+    datatype: date
+    max: ${ today() }
+---
+mandatory: True
+question: |
+  You were born on ${ birthdate }.

--- a/tests/features/TestExamples.feature
+++ b/tests/features/TestExamples.feature
@@ -8266,6 +8266,15 @@ Feature: Example interviews
     And I click the button "Continue"
     Then I should see the phrase "The date is April 1, 1989."
 
+  Scenario: Test the interview "Date limits"
+    Given I start the interview "docassemble.base:data/questions/examples/date-limit.yml"
+    Then I should see the phrase "What is your date of birth?"
+    And I set "Your birthday" to "04/19/2099"
+    Then I should see the phrase "You need to enter a date on or before"
+    And I set "Your birthday" to "04/19/1989"
+    And I click the button "Continue"
+    Then I should see the phrase "You were born on April 19, 1989."
+
   Scenario: Test the interview "Device local"
     Given I start the interview "docassemble.base:data/questions/examples/device-local.yml"
     Then I should see the phrase "How are you doing today?"


### PR DESCRIPTION
In the [docs on dates](https://docassemble.org/docs/fields.html#date), the default date description and the min/max description have the same example.

These should be separate. I'm making this PR first, and will add to the docs in the gh-pages branch once this goes in.

Also saw that there are tests for the examples now, I tried to add a test for the new example, but not sure if the "should see the phrase" command matches partial strings. We can't hardcode the exact string to see because it's setting a max of `today()`. Let me know if there's anything I should change there.