### PR TITLE
Don't throw error if no fields in a StaticFile

### DIFF
--- a/docassemble_base/docassemble/base/core.py
+++ b/docassemble_base/docassemble/base/core.py
@@ -4162,12 +4162,14 @@ class DAStaticFile(DAObject):
         """Returns a list of fields that exist in the PDF document"""
         results = list()
         import docassemble.base.pdftk
-        for item in docassemble.base.pdftk.read_fields(self.path()):
-            the_type = re.sub(r'[^/A-Za-z]', '', str(item[4]))
-            if the_type == 'None':
-                the_type = None
-            result = (item[0], '' if item[1] == 'something' else item[1], item[2], item[3], the_type, item[5])
-            results.append(result)
+        all_items = docassemble.base.pdftk.read_fields(self.path())
+        if all_items is not None:
+            for item in all_items: 
+                the_type = re.sub(r'[^/A-Za-z]', '', str(item[4]))
+                if the_type == 'None':
+                    the_type = None
+                result = (item[0], '' if item[1] == 'something' else item[1], item[2], item[3], the_type, item[5])
+                results.append(result)
         return results
     def url_for(self, **kwargs):
         """Returns a URL to the static file."""


### PR DESCRIPTION
Related to #363: fixes the same issue, but in DAStaticFile, which I missed at the time.