### PR TITLE
Updated device(ip=True) to work with reverse proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.2.88] - 2021-07-01
+- device(ip=True) now works with reverse proxies by returning X-Real-Ip or X-Forwarded-For if one of those is present.
+
 ## [1.2.87] - 2021-06-27
 ### Added
 - The `register_jinja_filter()` function.

--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -226,7 +226,12 @@ def device(ip=False):
 
     """
     if ip:
+        if this_thread.current_info['headers'].get('X-Real-Ip', None):
+            return this_thread.current_info['headers']['X-Real-Ip']
+        if this_thread.current_info['headers'].get('X-Forwarded-For', None):
+            return this_thread.current_info['headers']['X-Forwarded-For']
         return this_thread.current_info['clientip']
+        
     if 'headers' in this_thread.current_info:
         ua_string = this_thread.current_info['headers'].get('User-Agent', None)
         if ua_string is not None:


### PR DESCRIPTION
device(ip=True) now returns the proper client ip even when there is a reverse proxy. It now looks for  X-Real-Ip or X-Forwarded-For if one of those is present.