### PR TITLE
Let 'lambda' appear in the names of variables

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -4057,7 +4057,7 @@ def value(var):
         return eval(var, dict())
     except:
         pass
-    if re.search(r'[\(\)\n\r]|lambda', var):
+    if re.search(r'[\(\)\n\r]|lambda:|lambda ', var):
         raise Exception("value() is invalid: " + repr(var))
     frame = inspect.stack()[1][0]
     components = components_of(var)


### PR DESCRIPTION
[Lambda expressions](https://docs.python.org/3/reference/expressions.html#lambda) need to have either
a parameter list (and thus a space right after the 'lambda') or be immediately followed by a colon. The regex used
by the `value()` function to search for lambdas would improperly throw an error if the name of the
variable being sought contained the word 'lambda' anywhere, even if it wasn't a python lambda.

This change corrects the regex in `value` to only throw an error when the word lambda is followed by
a space or a colon.