### PR TITLE
Do not geocode without API credentials

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -1474,7 +1474,7 @@ class Address(DAObject):
         if 'google' in server.daconfig and 'api key' in server.daconfig['google'] and server.daconfig['google']['api key']:
             my_geocoder = GoogleV3(api_key=server.daconfig['google']['api key'])
         else:
-            my_geocoder = GoogleV3()
+            logmessage("You need a valid API key to geocode an address.")
         try_number = 0
         success = False
         results = None


### PR DESCRIPTION
Due to changes in Google's API policy, there is no more traditional free tier. You need an API with billing enabled.

Currently, if you try geocoding an address and the google API credentials are not stored in the config file, it throws an exception that is not trapped.