### PR TITLE
Allow loading files with spaces in the filename

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -27248,8 +27248,8 @@ def secure_filename_spaces_ok(filename):
     filename = filename.encode("ascii", "ignore").decode("ascii")
     for sep in os.path.sep, os.path.altsep:
         if sep:
-            filename = filename.replace(sep, " ")
-    filename = str(re.sub(r'[^A-Za-z0-9\_\.\- ]', '', "_".join(filename.split()))).strip("._ ")
+            filename = filename.replace(sep, "_")
+    filename = str(re.sub(r'[^A-Za-z0-9\_\.\- ]', '', " ".join(filename.split()))).strip("._ ")
     return filename
 
 def secure_filename(filename):


### PR DESCRIPTION
This fixes the backwards compatibility break [1.2.90](https://github.com/jhpyle/docassemble/releases/tag/v1.2.90) introduced and allows yaml filenames that contain spaces to be loaded implementing what [the changes](https://github.com/jhpyle/docassemble/commit/e8f455a113ff959bde7c0c06d60faab2e3be6bf1#diff-4c8bf136c393acf44c18098d2b935b3a005636e57574530acffdf552432360faR27246-R27253) in [1.2.105](https://github.com/jhpyle/docassemble/releases/tag/v1.2.105) should have done.