### PR TITLE
Add "skip undefined" option to DOCX template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ cleanup.sh
 docassemble_webapp/docassemble/webapp/static/index.html
 docassemble_webapp/docassemble/webapp/static/css
 docassemble_webapp/docassemble/webapp/static/js
+.history
+.vscode

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2,7 +2,7 @@ import mimetypes
 import traceback
 import re
 from jinja2 import ChainableUndefined
-from jinja2.runtime import StrictUndefined, UndefinedError, 
+from jinja2.runtime import StrictUndefined, UndefinedError
 from jinja2.exceptions import TemplateError
 from jinja2.environment import Environment
 from jinja2 import FileSystemLoader, select_autoescape, TemplateNotFound


### PR DESCRIPTION
Adds class `DASkipUndefined` which handles Jinja2 undefined, callable, attributes, etc. and returns an empty string. `__eq__` and `__ne__` both return False instead of empty string.

This makes it possible to use `skip undefined: True` with a DOCX file, such as in a custom `error action` that lets someone download work that is still in progress.

Test file demonstrating a template with both defined and undefined values:

```
---
mandatory: True
code: |
  users = "ABCDEF"
---
mandatory: True
question: |
  Hello, There
attachment: 
  docx template file: sample_word_template.docx
  skip undefined: True
```
[sample_word_template.docx](https://github.com/jhpyle/docassemble/files/7445044/sample_word_template.docx)


