### PR TITLE
Corrected an error in DAGoogleAPI examples

### DIFF
--- a/_docs/objects.md
+++ b/_docs/objects.md
@@ -3441,8 +3441,12 @@ __all__ = ['get_folder_names', 'get_files_in_folder', 'write_file_to_folder', 'd
 def get_folder_names():
     service = api.drive_service()
     items = list()
+    page_token = None
     while True:
-        response = service.files().list(spaces="drive", fields="nextPageToken, files(id, name)", q="mimeType='application/vnd.google-apps.folder' and sharedWithMe").execute()
+        response = service.files().list(spaces="drive", 
+            fields="nextPageToken, files(id, name)", 
+            q="mimeType='application/vnd.google-apps.folder' and sharedWithMe"
+            pageToken=page_token).execute()
         for the_file in response.get('files', []):
             items.append(the_file)
         page_token = response.get('nextPageToken', None)
@@ -3452,7 +3456,9 @@ def get_folder_names():
 
 def get_folder_id(folder_name):
     service = api.drive_service()
-    response = service.files().list(spaces="drive", fields="nextPageToken, files(id, name)", q="mimeType='application/vnd.google-apps.folder' and sharedWithMe and name='" + unicode(folder_name) + "'").execute()
+    response = service.files().list(spaces="drive", 
+        fields="nextPageToken, files(id, name)", 
+        q="mimeType='application/vnd.google-apps.folder' and sharedWithMe and name='" + unicode(folder_name) + "'").execute()
     folder_id = None
     for item in response.get('files', []):
         folder_id = item['id']
@@ -3464,7 +3470,9 @@ def get_file_id(filename, folder_name):
         raise Exception("The folder was not found")
     service = api.drive_service()
     file_id = None
-    response = service.files().list(spaces="drive", fields="nextPageToken, files(id, name)", q="mimeType!='application/vnd.google-apps.folder' and '" + str(folder_id) + "' in parents and name='" + unicode(filename) + "'").execute()
+    response = service.files().list(spaces="drive", 
+        fields="nextPageToken, files(id, name)", 
+        q="mimeType!='application/vnd.google-apps.folder' and '" + str(folder_id) + "' in parents and name='" + unicode(filename) + "'").execute()
     for item in response.get('files', []):
         file_id = item['id']
     return file_id
@@ -3475,8 +3483,12 @@ def get_files_in_folder(folder_name):
         raise Exception("The folder was not found")
     service = api.drive_service()
     items = list()
+    page_token = None
     while True:
-        response = service.files().list(spaces="drive", fields="nextPageToken, files(id, name)", q="mimeType!='application/vnd.google-apps.folder' and trashed=false and '" + str(folder_id) + "' in parents").execute()
+        response = service.files().list(spaces="drive", 
+            fields="nextPageToken, files(id, name)", 
+            q="mimeType!='application/vnd.google-apps.folder' and trashed=false and '" + str(folder_id) + "' in parents"
+            pageToken=page_token).execute()
         for the_file in response.get('files', []):
             items.append(the_file)
         page_token = response.get('nextPageToken', None)


### PR DESCRIPTION
The examples were checking a page token to see if there were
more results for a particular search, but they never reused
that page token for the next query, leading to an infinite loop.