### PR TITLE
Multiple spaces in filename regression.

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -27689,7 +27689,7 @@ def secure_filename_spaces_ok(filename):
     for sep in os.path.sep, os.path.altsep:
         if sep:
             filename = filename.replace(sep, "_")
-    filename = str(re.sub(r'[^A-Za-z0-9\_\.\- ]', '', " ".join(filename.split()))).strip("._ ")
+    filename = str(re.sub(r'[^A-Za-z0-9\_\.\- ]', '', " ".join(filename.split(' ')))).strip("._ ")
     return filename
 
 def secure_filename(filename):


### PR DESCRIPTION
This is in addition to https://github.com/jhpyle/docassemble/pull/462 to support backwards compatibility for filenames that have multiple consecutive spaces.