### PR TITLE
Fix undeclared imports and variables

### DIFF
--- a/docassemble_base/docassemble/base/error.py
+++ b/docassemble_base/docassemble/base/error.py
@@ -89,7 +89,7 @@ class ForcedNameError(NameError):
                         self.set_action(dict(action='_da_set', arguments=dict(variables=clean_list), context=the_context))
                     if 'follow up' in arg:
                         if isinstance(arg['follow up'], str):
-                            arg[command] = [arg['follow up']]
+                            arg['follow up'] = [arg['follow up']]
                         if not isinstance(arg['follow up'], list):
                             raise DAError("force_ask: the follow up statement must refer to a list.")
                         for var in arg['follow up']:

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -396,7 +396,7 @@ class DAWeb(DAObject):
             task_persistent = self.task_persistent
         if task_persistent is None:
             return False
-        if not isinstance(task, (bool, str)):
+        if not isinstance(task_persistent, (bool, str)):
             raise Exception("DAWeb.call: task_persistent must be boolean or string")
         return task_persistent
     def _get_auth(self, auth):
@@ -1681,7 +1681,7 @@ class Address(DAObject):
         if self.city_only:
             return ''
         if (not hasattr(self, 'address')) and hasattr(self, 'street_number') and hasattr(self, 'street'):
-            output += str(self.street_number) + " " + str(self.street)
+            output = str(self.street_number) + " " + str(self.street)
         else:
             output = str(self.address)
         the_unit = self.formatted_unit(language=language)

--- a/docassemble_webapp/docassemble/webapp/listlog.py
+++ b/docassemble_webapp/docassemble/webapp/listlog.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from flask import Flask, make_response, render_template, request
+from flask import Flask, abort, make_response, render_template, request
 app = Flask(__name__)
 
 LOG_DIRECTORY = '/var/www/html/log'

--- a/docassemble_webapp/docassemble/webapp/users/forms.py
+++ b/docassemble_webapp/docassemble/webapp/users/forms.py
@@ -9,6 +9,8 @@ from docassemble.base.functions import LazyWord as word, LazyArray
 from docassemble.base.config import daconfig
 from flask_login import current_user
 import email.utils
+from sqlalchemy import select
+
 HTTP_TO_HTTPS = daconfig.get('behind https load balancer', False)
 
 def get_requester_ip(req):

--- a/docassemble_webapp/docassemble/webapp/users/forms.py
+++ b/docassemble_webapp/docassemble/webapp/users/forms.py
@@ -224,7 +224,7 @@ class MyInviteForm(FlaskForm):
             return False
         return super().validate()
     email = TextAreaField(word('One or more e-mail addresses (separated by newlines)'), validators=[
-        validators.Required(word('At least one e-mail address must be listed'))
+        validators.InputRequired(word('At least one e-mail address must be listed'))
     ])
     role_id = SelectField(word('Role'))
     next = HiddenField()
@@ -232,7 +232,7 @@ class MyInviteForm(FlaskForm):
 
 class UserAddForm(FlaskForm):
     email = StringField(word('E-mail'), validators=[
-        validators.Required(word('E-mail is required')),
+        validators.InputRequired(word('E-mail is required')),
         validators.Email(word('Invalid E-mail'))])
     first_name = StringField(word('First name'), [validators.Length(min=0, max=255)])
     last_name = StringField(word('Last name'), [validators.Length(min=0, max=255)])


### PR DESCRIPTION
Had a report that `NameError: name 'select' is not defined` happened webapp/user/forms.py today on production. When fixing that (which was a simple missing import), I started fixing a few other related 'undeclared variable' errors that I picked up from pylint. I haven't run into those issues on production, but they do seem to be real bugs. All of the bugs I haven't personally seen or had reported I stuck in the 2nd commit, if you wish to examine them closer or test yourself.