### PR TITLE
Safety when user_logged_in is called outside of interview context

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -202,7 +202,7 @@ def get_current_question():
 
 def user_logged_in():
     """Returns True if the user is logged in, False otherwise."""
-    if this_thread.current_info['user']['is_authenticated']:
+    if this_thread.current_info.get('user',{}).get('is_authenticated'):
         return True
     return False
 


### PR DESCRIPTION
I ran into this error today in our automated tests when I called `user_info().package` from a pre-load hook:

```
   File "/home/runner/work/docassemble-ALWeaver/docassemble-ALWeaver/docassemble/ALWeaver/custom_values.py", line 134, in <module>
    advertise_capabilities()
  File "/home/runner/work/docassemble-ALWeaver/docassemble-ALWeaver/docassemble/ALWeaver/custom_values.py", line 129, in advertise_capabilities
    package_name = user_info().package
  File "/home/runner/work/docassemble-ALWeaver/docassemble-ALWeaver/venv/lib/python3.8/site-packages/docassemble/base/functions.py", line 689, in user_info
    if user_logged_in():
  File "/home/runner/work/docassemble-ALWeaver/docassemble-ALWeaver/venv/lib/python3.8/site-packages/docassemble/base/functions.py", line 219, in user_logged_in
    if this_thread.current_info['user']['is_authenticated']:
KeyError: 'user'
```

Looks like this_thread.current_info['user'] isn't always defined.