### PR TITLE
Handle API github pull url complexities internally

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -18596,17 +18596,15 @@ def do_playground_pull(area, current_project, github_url=None, branch=None, pypi
     expected_name = 'unknown'
     if github_url:
         github_url = re.sub(r'[^A-Za-z0-9\-\.\_\~\:\/\#\[\]\@\$\+\,\=]', '', github_url)
-        expected_name = re.sub(r'.*/', '', github_url)
-        expected_name = re.sub(r'\.git', '', expected_name)
-        expected_name = re.sub(r'docassemble-', '', expected_name)
-        repo_url_info = re.sub(r'github_url=', '', github_url)
-        repo_url_info = re.sub(r'git@github.com:', '', repo_url_info)
-        repo_url_info = re.sub(r'https://github.com/', '', repo_url_info)
-        repo_url_info = re.sub(r'\.git', '', repo_url_info)
-        url_user_name = repo_url_info.split("/")[0]
-        url_package_name = repo_url_info.split("/")[1]
-        if can_publish_to_github and github_email:
-            github_url = f'git@github.com:{url_user_name}/{url_package_name}.git'
+        repo_name = re.sub(r'/*$', '', github_url)
+        repo_name = re.sub(r'^http.*github.com/', '', repo_name)
+        repo_name = re.sub(r'.*@github.com:', '', repo_name)
+        repo_name = re.sub(r'.git$', '', repo_name)
+        if not 'x-oauth-basic@github.com' in github_url and can_publish_to_github and github_email:
+            github_url = f'git@github.com:{repo_name}.git'
+            expected_name = re.sub(r'.*/', '', github_url)
+            expected_name = re.sub(r'\.git', '', expected_name)
+            expected_name = re.sub(r'docassemble-', '', expected_name)
             (private_key_file, public_key_file) = get_ssh_keys(github_email)
             os.chmod(private_key_file, stat.S_IRUSR | stat.S_IWUSR)
             os.chmod(public_key_file, stat.S_IRUSR | stat.S_IWUSR)
@@ -18623,7 +18621,11 @@ def do_playground_pull(area, current_project, github_url=None, branch=None, pypi
                 output += err.output.decode()
                 return dict(action="error", message="error running git clone.  " + output)
         else:
-            github_url = f'https://github.com/{url_user_name}/{url_package_name}'
+            if not github_url.startswith('http'):
+                github_url = f'https://github.com/{repo_name}'
+            expected_name = re.sub(r'.*/', '', github_url)
+            expected_name = re.sub(r'\.git', '', expected_name)
+            expected_name = re.sub(r'docassemble-', '', expected_name)
             try:
                 if branch is not None:
                     logmessage("Doing git clone -b " + branch + " " + github_url)

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -18596,10 +18596,17 @@ def do_playground_pull(area, current_project, github_url=None, branch=None, pypi
     expected_name = 'unknown'
     if github_url:
         github_url = re.sub(r'[^A-Za-z0-9\-\.\_\~\:\/\#\[\]\@\$\+\,\=]', '', github_url)
-        if github_url.startswith('git@') and can_publish_to_github and github_email:
-            expected_name = re.sub(r'.*/', '', github_url)
-            expected_name = re.sub(r'\.git', '', expected_name)
-            expected_name = re.sub(r'docassemble-', '', expected_name)
+        expected_name = re.sub(r'.*/', '', github_url)
+        expected_name = re.sub(r'\.git', '', expected_name)
+        expected_name = re.sub(r'docassemble-', '', expected_name)
+        repo_url_info = re.sub(r'github_url=', '', github_url)
+        repo_url_info = re.sub(r'git@github.com:', '', repo_url_info)
+        repo_url_info = re.sub(r'https://github.com/', '', repo_url_info)
+        repo_url_info = re.sub(r'\.git', '', repo_url_info)
+        url_user_name = repo_url_info.split("/")[0]
+        url_package_name = repo_url_info.split("/")[1]
+        if can_publish_to_github and github_email:
+            github_url = f'git@github.com:{url_user_name}/{url_package_name}.git'
             (private_key_file, public_key_file) = get_ssh_keys(github_email)
             os.chmod(private_key_file, stat.S_IRUSR | stat.S_IWUSR)
             os.chmod(public_key_file, stat.S_IRUSR | stat.S_IWUSR)
@@ -18616,9 +18623,7 @@ def do_playground_pull(area, current_project, github_url=None, branch=None, pypi
                 output += err.output.decode()
                 return dict(action="error", message="error running git clone.  " + output)
         else:
-            expected_name = re.sub(r'.*/', '', github_url)
-            expected_name = re.sub(r'\.git', '', expected_name)
-            expected_name = re.sub(r'docassemble-', '', expected_name)
+            github_url = f'https://github.com/{url_user_name}/{url_package_name}'
             try:
                 if branch is not None:
                     logmessage("Doing git clone -b " + branch + " " + github_url)


### PR DESCRIPTION
No matter the address handed in, if the user has github integration then try using ssh to pull. If they don't, use a non-ssh cloning address.

When pulling from GitHub, a private repo needs a `git@` url to use SSH instead of the non-ssh url. If github integration isn't set up, though, trying to use the SSH url will cause an error. Currently, when the `playground_pull` API is used, the requester has to know which url to send.

It occurred to me that instead of requiring the requester to know whether a person's repository was private, or whether a user has github integration, docassemble's API may be able to use the knowledge it has about the user's github integration to give it the best shot it could have.

I had a hard time telling if `do_playground_pull()` is also used to install repositories on a server as opposed to just in a Project, so I added provisions for a personal access token url as well. If we don't need that, this code can be simplified a bit.