### PR TITLE
Make DAStore work when not in an interactive session

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -352,7 +352,14 @@ class DAStore(DAObject):
     def set(self, key, value):
         """Writes an object to the data store under the given key."""
         the_key = self._get_base_key() + ':' + key
-        server.server_sql_set(the_key, value, encrypted=self.is_encrypted(), secret=this_thread.current_info.get('secret', None), the_user_id=this_thread.current_info['user']['the_user_id'])
+        if self.is_encrypted():
+            secret = this_thread.current_info.get('secret', None)
+        else:
+            secret = None
+        if the_key.startswith("da:userid:"):
+            server.server_sql_set(the_key, value, encrypted=self.is_encrypted(), secret=secret, the_user_id=this_thread.current_info['user']['the_user_id'])
+        else:
+            server.server_sql_set(the_key, value, encrypted=self.is_encrypted(), secret=secret, the_user_id=None)
     def delete(self, key):
         """Deletes an object from the data store"""
         the_key = self._get_base_key() + ':' + key

--- a/docassemble_webapp/docassemble/webapp/backend.py
+++ b/docassemble_webapp/docassemble/webapp/backend.py
@@ -247,7 +247,10 @@ def sql_defined(key):
     return True
 
 def sql_set(key, val, encrypted=True, secret=None, the_user_id=None):
-    user_id, temp_user_id = parse_the_user_id(the_user_id)
+    if the_user_id:
+        user_id, temp_user_id = parse_the_user_id(the_user_id)
+    else:
+        user_id = temp_user_id = None
     updated = False
     for record in db.session.execute(select(GlobalObjectStorage).filter_by(key=key).with_for_update()).scalars():
         record.user_id = user_id


### PR DESCRIPTION
Currently DAStore.set() fails when run in a non-interactive context, as Docassemble is unable to get the value of `this_thread.current_info['user']['the_user_id']`. However, the SQL record can be written fine with `user_id` set to None.

This patches DAStore.set() to see if the `user_id` is actually required to save to the DAStore after checking the value of DAStore.base.

Here's an example module that fails with the current behavior:

```python
# pre-load

import os
from docassemble.base.util import DAStore, log

__all__ = ['advertise_capabilities']

def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver", minimum_version="1.5"):
  weaverdata = DAStore(base=base)
  if not package_name:
    package_name = __name__    
  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
  if not isinstance(published_configuration_capabilities, dict):
    published_configuration_capabilities = {}
  published_configuration_capabilities[package_name] = [yaml_name, minimum_version]
  log(published_configuration_capabilities)
  weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
  
# After docassemble.demo.test is removed from #pre-load we can also check 'unittest' in sys.modules.keys()  
#if not os.environ.get('ISUNITTEST'):
advertise_capabilities()
```