### PR TITLE
Return $.ajax Promise for `get_interview_variables()`

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -8526,7 +8526,7 @@ def index(action_argument=None, refer=None):
         if (callback == null){
           callback = function(){};
         }
-        $.ajax({
+        return $.ajax({
           type: "GET",
           url: """ + '"' + url_for('get_variables', i=yaml_filename) + '"' + """,
           success: callback,
@@ -13237,7 +13237,7 @@ def observer():
         if (callback == null){
           callback = function(){};
         }
-        $.ajax({
+        return $.ajax({
           type: "GET",
           url: """ + '"' + url_for('get_variables', i=i) + '"' + """,
           success: callback,


### PR DESCRIPTION
I can do it with the others as well, but this was the function I could test at the moment.

Returning a Promise makes it easier for developers using that function to `await` the results synchronously or chain with `.then()` etc. [They can also continue to use the callback.]