### PR TITLE
Updated to docxtpl 0.15.2

### DIFF
--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -10,7 +10,7 @@ import subprocess
 from collections import deque
 from copy import deepcopy
 from xml.sax.saxutils import escape as html_escape
-from docxtpl import InlineImage, RichText, Document, DocxTemplate
+from docxtpl import InlineImage, RichText
 from docx.shared import Mm, Inches, Pt, Cm, Twips
 import docx.opc.constants
 from docx.oxml.section import CT_SectPr # For figuring out if an element is a section or not
@@ -127,7 +127,7 @@ def include_docx_template(template_file, **kwargs):
     else:
         template_path = package_template_filename(template_file, package=this_thread.current_package)
     sd = this_thread.misc['docx_template'].new_subdoc()
-    sd.subdocx = Document(template_path)
+    sd.subdocx = docx.Document(template_path)
     if not use_jinja:
         return sanitize_xml(str(sd))
     if '_inline' in kwargs:

--- a/docassemble_base/setup.py
+++ b/docassemble_base/setup.py
@@ -82,7 +82,7 @@ install_requires = [
     "docopt==0.6.2",
     "docutils==0.17.1",
     "docxcompose==1.3.2",
-    "docxtpl==0.11.5",
+    "docxtpl==0.15.2",
     "et-xmlfile==1.1.0",
     "future==0.18.2",
     "geographiclib==1.50",

--- a/docassemble_webapp/setup.py
+++ b/docassemble_webapp/setup.py
@@ -64,7 +64,7 @@ install_requires = [
     "docopt==0.6.2",
     "docutils==0.17.1",
     "docxcompose==1.3.2",
-    "docxtpl==0.11.5",
+    "docxtpl==0.15.2",
     "email-validator==1.1.2",
     "et-xmlfile==1.1.0",
     "eventlet==0.31.0",


### PR DESCRIPTION
More recent versions `docxtpl` have fixed issues with including sub-docs with images, among other things (https://github.com/elapouya/python-docx-template/blob/master/CHANGES.rst#0120-2021-08-15). However, there were some internal refactors in the library in 0.12, which caused DA to break. Document was removed, however, it seems to be because `Document` was actually a class from the `docx` library. Changing DA references to `Document` in the file_docx.py class allows us to use any version of docxtpl. 