### PR TITLE
Update docxtpl

### DIFF
--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -10,7 +10,7 @@ import subprocess
 from collections import deque
 from copy import deepcopy
 from xml.sax.saxutils import escape as html_escape
-from docxtpl import InlineImage, RichText, Document, DocxTemplate
+from docxtpl import InlineImage, RichText
 from docx.shared import Mm, Inches, Pt, Cm, Twips
 import docx.opc.constants
 from docx.oxml.section import CT_SectPr # For figuring out if an element is a section or not
@@ -127,7 +127,7 @@ def include_docx_template(template_file, **kwargs):
     else:
         template_path = package_template_filename(template_file, package=this_thread.current_package)
     sd = this_thread.misc['docx_template'].new_subdoc()
-    sd.subdocx = Document(template_path)
+    sd.subdocx = docx.Document(template_path)
     if not use_jinja:
         return sanitize_xml(str(sd))
     if '_inline' in kwargs:

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -4737,9 +4737,10 @@ class Question:
                             the_docx_path = docassemble.base.file_docx.concatenate_files(template_files)
                         try:
                             docx_template = DocxTemplate(the_docx_path)
+                            docx_template.render_init()
                             the_env = custom_jinja_env(skip_undefined = options['skip_undefined'])
                             the_xml = docx_template.get_xml()
-                            the_xml = re.sub(r'<w:p>', '\n<w:p>', the_xml)
+                            the_xml = re.sub(r'<w:p([ >])', r'\n<w:p\1', the_xml)
                             the_xml = re.sub(r'({[\%\{].*?[\%\}]})', fix_quotes, the_xml)
                             the_xml = docx_template.patch_xml(the_xml)
                             parsed_content = the_env.parse(the_xml)
@@ -6249,6 +6250,7 @@ class Question:
                                         with tempfile.NamedTemporaryFile(prefix="datemp", mode="wb", suffix=".docx", delete=False) as new_template_file:
                                             the_template.save(new_template_file.name) # Save and refresh the template
                                             the_template = DocxTemplate(new_template_file.name)
+                                            the_template.render_init()
                                             if result['hyperlink_style'] and result['hyperlink_style'] in the_template.docx.styles:
                                                 the_template.da_hyperlink_style = result['hyperlink_style']
                                             elif 'Hyperlink' in result['template'].docx.styles:
@@ -6566,6 +6568,7 @@ class Question:
                             else:
                                 docx_path = docassemble.base.file_docx.concatenate_files(docx_paths)
                             result['template'] = DocxTemplate(docx_path)
+                            result['template'].render_init()
                             if result['hyperlink_style'] and result['hyperlink_style'] in result['template'].docx.styles:
                                 result['template'].da_hyperlink_style = result['hyperlink_style']
                             elif 'Hyperlink' in result['template'].docx.styles:
@@ -9598,9 +9601,10 @@ def get_docx_variables(the_path):
         raise DAError("Missing docx template file " + os.path.basename(the_path))
     try:
         docx_template = DocxTemplate(the_path)
+        docx_template.render_init()
         the_env = custom_jinja_env()
         the_xml = docx_template.get_xml()
-        the_xml = re.sub(r'<w:p>', '\n<w:p>', the_xml)
+        the_xml = re.sub(r'<w:p([ >])', r'\n<w:p\1', the_xml)
         the_xml = re.sub(r'({[\%\{].*?[\%\}]})', fix_quotes, the_xml)
         the_xml = docx_template.patch_xml(the_xml)
         parsed_content = the_env.parse(the_xml)

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -33,6 +33,7 @@ from jinja2 import meta as jinja2meta
 from jinja2.lexer import Token
 from jinja2.utils import internalcode, missing, object_type_repr
 from jinja2.ext import Extension
+from docxtpl import DocxTemplate
 import pandas
 import dateutil.parser
 import pytz
@@ -4735,7 +4736,7 @@ class Question:
                         else:
                             the_docx_path = docassemble.base.file_docx.concatenate_files(template_files)
                         try:
-                            docx_template = docassemble.base.file_docx.DocxTemplate(the_docx_path)
+                            docx_template = DocxTemplate(the_docx_path)
                             the_env = custom_jinja_env(skip_undefined = options['skip_undefined'])
                             the_xml = docx_template.get_xml()
                             the_xml = re.sub(r'<w:p>', '\n<w:p>', the_xml)
@@ -6247,7 +6248,7 @@ class Question:
                                         # There's another template included
                                         with tempfile.NamedTemporaryFile(prefix="datemp", mode="wb", suffix=".docx", delete=False) as new_template_file:
                                             the_template.save(new_template_file.name) # Save and refresh the template
-                                            the_template = docassemble.base.file_docx.DocxTemplate(new_template_file.name)
+                                            the_template = DocxTemplate(new_template_file.name)
                                             if result['hyperlink_style'] and result['hyperlink_style'] in the_template.docx.styles:
                                                 the_template.da_hyperlink_style = result['hyperlink_style']
                                             elif 'Hyperlink' in result['template'].docx.styles:
@@ -6564,7 +6565,7 @@ class Question:
                                 docx_path = docx_paths[0]
                             else:
                                 docx_path = docassemble.base.file_docx.concatenate_files(docx_paths)
-                            result['template'] = docassemble.base.file_docx.DocxTemplate(docx_path)
+                            result['template'] = DocxTemplate(docx_path)
                             if result['hyperlink_style'] and result['hyperlink_style'] in result['template'].docx.styles:
                                 result['template'].da_hyperlink_style = result['hyperlink_style']
                             elif 'Hyperlink' in result['template'].docx.styles:
@@ -9596,7 +9597,7 @@ def get_docx_variables(the_path):
     if not os.path.isfile(the_path):
         raise DAError("Missing docx template file " + os.path.basename(the_path))
     try:
-        docx_template = docassemble.base.file_docx.DocxTemplate(the_path)
+        docx_template = DocxTemplate(the_path)
         the_env = custom_jinja_env()
         the_xml = docx_template.get_xml()
         the_xml = re.sub(r'<w:p>', '\n<w:p>', the_xml)

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -58,7 +58,7 @@ from bs4 import BeautifulSoup
 import i18naddress
 from flask_mail import Message
 from pyzbar.pyzbar import decode
-from docxtpl import InlineImage, Subdoc
+from docxtpl import InlineImage, Subdoc, DocxTemplate
 #import tablib
 import pandas
 import PyPDF2
@@ -8097,7 +8097,7 @@ def assemble_docx(input_file, fields=None, output_path=None, output_format='docx
     if isinstance(fields, dict):
         the_fields.update(fields)
     try:
-        docx_template = docassemble.base.file_docx.DocxTemplate(input_file)
+        docx_template = DocxTemplate(input_file)
         docassemble.base.functions.set_context('docx', template=docx_template)
         the_env = docassemble.base.parse.custom_jinja_env()
         the_xml = docx_template.get_xml()
@@ -8111,7 +8111,7 @@ def assemble_docx(input_file, fields=None, output_path=None, output_format='docx
             if docassemble.base.functions.this_thread.misc.get('docx_include_count', 0) > old_count and old_count < 10:
                 new_template_file = tempfile.NamedTemporaryFile(prefix="datemp", mode="wb", suffix=".docx", delete=False)
                 docx_template.save(new_template_file.name)
-                docx_template = docassemble.base.file_docx.DocxTemplate(new_template_file.name)
+                docx_template = DocxTemplate(new_template_file.name)
                 docassemble.base.functions.this_thread.misc['docx_template'] = docx_template
             else:
                 break

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -8098,10 +8098,11 @@ def assemble_docx(input_file, fields=None, output_path=None, output_format='docx
         the_fields.update(fields)
     try:
         docx_template = DocxTemplate(input_file)
+        docx_template.render_init()
         docassemble.base.functions.set_context('docx', template=docx_template)
         the_env = docassemble.base.parse.custom_jinja_env()
         the_xml = docx_template.get_xml()
-        the_xml = re.sub(r'<w:p>', '\n<w:p>', the_xml)
+        the_xml = re.sub(r'<w:p([ >])', r'\n<w:p\1', the_xml)
         the_xml = re.sub(r'({[\%\{].*?[\%\}]})', docassemble.base.parse.fix_quotes, the_xml)
         the_xml = docx_template.patch_xml(the_xml)
         the_env.parse(the_xml)
@@ -8112,6 +8113,7 @@ def assemble_docx(input_file, fields=None, output_path=None, output_format='docx
                 new_template_file = tempfile.NamedTemporaryFile(prefix="datemp", mode="wb", suffix=".docx", delete=False)
                 docx_template.save(new_template_file.name)
                 docx_template = DocxTemplate(new_template_file.name)
+                docx_template.render_init()
                 docassemble.base.functions.this_thread.misc['docx_template'] = docx_template
             else:
                 break

--- a/docassemble_base/setup.py
+++ b/docassemble_base/setup.py
@@ -82,7 +82,7 @@ install_requires = [
     "docopt==0.6.2",
     "docutils==0.17.1",
     "docxcompose==1.3.2",
-    "docxtpl==0.11.5",
+    "docxtpl==0.15.2",
     "et-xmlfile==1.1.0",
     "future==0.18.2",
     "geographiclib==1.50",

--- a/docassemble_webapp/setup.py
+++ b/docassemble_webapp/setup.py
@@ -64,7 +64,7 @@ install_requires = [
     "docopt==0.6.2",
     "docutils==0.17.1",
     "docxcompose==1.3.2",
-    "docxtpl==0.11.5",
+    "docxtpl==0.15.2",
     "email-validator==1.1.2",
     "et-xmlfile==1.1.0",
     "eventlet==0.31.0",


### PR DESCRIPTION
Re-attempt of #504.

More recent versions docxtpl have fixed issues with including sub-docs with images, among other things (https://github.com/elapouya/python-docx-template/blob/master/CHANGES.rst#0120-2021-08-15). However, there were some internal refactors in the library in 0.12, which caused DA to break. 
* Document was removed, however, it seems to be because Document was actually a class from the docx library. Changing DA references to Document in the file_docx.py class allows us to use any version of docxtpl.
* [multiple rendering on the same doc](https://github.com/elapouya/python-docx-template/commit/589262664f30890e58e8cabbec0c80321f4ccdf2) was added, which means we need to explicitly call `render_init` before grabbing the XML
* the regex that added newlines for new paragraphs wasn't catching paragraph tags with attributes: also copied the regex from https://github.com/elapouya/python-docx-template/pull/398 (which seemed to be the basis for the existing regexes)

Manually tested using the general DOCX attachment rendering, also also with an `include_docx_template` subdoc example.