### PR TITLE
Correct executable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ foobar.pickle
 */build
 *.egg-info
 */dist
+.git/**
 make_session_store.py
 da.wsgi
 oauth.wsgi

--- a/Docker/config/docassemble.ini.dist
+++ b/Docker/config/docassemble.ini.dist
@@ -11,3 +11,4 @@ venv = {{DA_PYTHON}}
 pidfile = /var/run/uwsgi/uwsgi.pid
 buffer-size = 32768
 touch-reload = {{DA_ROOT}}/webapp/docassemble.wsgi
+py-executable = {{DA_PYTHON}}/bin/python

--- a/docassemble_webapp/setup.py
+++ b/docassemble_webapp/setup.py
@@ -236,7 +236,7 @@ install_requires = [
     "urllib3==1.26.5",
     "us==2.0.2",
     "user-agents==2.2.0",
-    "uWSGI==2.0.19.1",
+    "uWSGI==2.0.20",
     "vine==5.0.0",
     "wcwidth==0.2.5",
     "webdriver-manager==3.4.1",


### PR DESCRIPTION
I recently ran into [a bug where `sys.executable` wasn't `python`](https://docassemble.slack.com/archives/C7791ATUJ/p1645831035613809?thread_ts=1645713090.060679&cid=C7791ATUJ), as it should be. I checked out uWSGI, and they just [fixed this bug in the most recent version](https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.20.html?highlight=sys.executable#changes). There are a few other updates as well, but they mostly look like bug fixes.

I tested this on a new docassemble docker image, and the `sys.executable` is `python`, as expected. Using this demo interview:
```
imports:
  - sys
---
mandatory: True
question: |
  sys.executable:
subquestion: |
  ${ sys.executable }
---
```
 gives the following on docassemble without this patch:
![Screenshot from 2022-03-22 15-36-35](https://user-images.githubusercontent.com/6252212/159562847-c91df73b-2686-4bc0-951b-0fabe52966f5.png)

and gives the follow on docassemble with this patch:
![Screenshot from 2022-03-22 15-36-01](https://user-images.githubusercontent.com/6252212/159562908-6ae1b31a-7c12-4068-8162-474f0cb91846.png)
 
 Additionally, I added the `.git` folder to the `.dockerignore` file. Currently, the .git folder in docassemble is 301MB, and is the majority of the disk usage. Preventing it from being sent to the docker daemon when building a docker image speeds it up a lot.