### PR TITLE
Add optgroups

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -5674,6 +5674,8 @@ class Question:
                                     new_item['help'] = candidate['help'].text(user_dict)
                                 if 'default' in candidate:
                                     new_item['default'] = candidate['default']
+                                if 'group' in candidate:
+                                    new_item['group'] = candidate['group']
                                 if new_item['key'] not in to_exclude:
                                     selectcompute[field.number].append(new_item)
                         else:
@@ -5689,6 +5691,8 @@ class Question:
                                     new_item['help'] = item['help'].text(user_dict)
                                 if 'default' in item:
                                     new_item['default'] = item['default']
+                                if 'group' in item:
+                                    new_item['group'] = item['group']
                                 selectcompute[field.number].append(new_item)
                         if len(selectcompute[field.number]) > 0:
                             only_empty_fields_exist = False
@@ -5705,6 +5709,8 @@ class Question:
                                 new_item['help'] = item['help'].text(user_dict)
                             if 'default' in item:
                                 new_item['default'] = item['default']
+                            if 'group' in item:
+                                new_item['group'] = item['group']
                             if isinstance(item['key'], TextObject):
                                 new_item['key'] = item['key'].text(user_dict)
                             else:
@@ -5726,6 +5732,8 @@ class Question:
                                 new_item['help'] = item['help'].text(user_dict)
                             if 'default' in item:
                                 new_item['default'] = item['default']
+                            if 'group' in item:
+                                new_item['group'] = item['group']
                             new_item['label'] = item['label'].text(user_dict)
                             new_item['key'] = item['key']
                             selectcompute[field.number].append(new_item)
@@ -6086,6 +6094,7 @@ class Question:
     def parse_fields(self, the_list, register_target, uses_field):
         result_list = []
         has_code = False
+        logmessage(f'the_list: {the_list}, uses_field: {uses_field}')
         if isinstance(the_list, dict):
             new_list = []
             for key, value in the_list.items():
@@ -6111,6 +6120,9 @@ class Question:
                         continue
                     if key == 'default':
                         result_dict['default'] = value
+                        continue
+                    if key == 'group':
+                        result_dict['group'] = value
                         continue
                 if uses_field:
                     if key == 'code':
@@ -6878,12 +6890,14 @@ class Question:
                     the_item = {}
                     for key in entry:
                         if len(entry) > 1:
-                            if key in ['default', 'help', 'image']:
+                            if key in ['default', 'help', 'image', 'group']:
                                 continue
                             if 'key' in entry and 'label' in entry and key != 'key':
                                 continue
                             if 'default' in entry:
                                 the_item['default'] = entry['default']
+                            if 'group' in entry:
+                                the_item['group'] = entry['group']
                             if 'help' in entry:
                                 the_item['help'] = TextObject(entry['help'], question=self)
                             if 'image' in entry:

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -3971,6 +3971,8 @@ class Question:
                     #     field_info['extras'][key] = TextObject(definitions + str(field[key]), question=self)
                     elif key == 'shuffle':
                         field_info['shuffle'] = field[key]
+                    elif key == 'group':
+                        field_info['group'] = field[key]
                     elif key == 'none of the above' and 'datatype' in field and field['datatype'] in ('checkboxes', 'object_checkboxes', 'object_radio'):
                         if isinstance(field[key], bool):
                             field_info['nota'] = field[key]
@@ -5576,6 +5578,8 @@ class Question:
                                     new_item['help'] = choice['help'].text(user_dict)
                                 if 'default' in choice:
                                     new_item['default'] = choice['default']
+                                if 'group' in choice:
+                                    new_item['group'] = choice['group']
                                 if isinstance(choice['key'], TextObject):
                                     new_item['key'] = choice['key'].text(user_dict)
                                 else:
@@ -8886,12 +8890,14 @@ def process_selections(data, exclude=None):
                 the_item = {}
                 for key in entry:
                     if len(entry) > 1:
-                        if key in ['default', 'help', 'image', 'label']:
+                        if key in ['default', 'help', 'image', 'label', 'group']:
                             continue
                         if 'default' in entry:
                             the_item['default'] = entry['default']
                         if 'help' in entry:
                             the_item['help'] = entry['help']
+                        if 'group' in entry:
+                            the_item['group'] = entry['group']
                         if 'image' in entry:
                             if entry['image'].__class__.__name__ == 'DAFile':
                                 entry['image'].retrieve()
@@ -8920,7 +8926,7 @@ def process_selections(data, exclude=None):
                         the_item['label'] = entry[key]
                         is_not_boolean = False
                         for key, val in entry.items():
-                            if key in ['default', 'help', 'image', 'label']:
+                            if key in ['default', 'help', 'image', 'label', 'group']:
                                 continue
                             if val not in (True, False):
                                 is_not_boolean = True

--- a/docassemble_base/docassemble/base/standardformatter.py
+++ b/docassemble_base/docassemble/base/standardformatter.py
@@ -1457,10 +1457,25 @@ def as_html(status, debug, root, validation_rules, field_error, the_progress_bar
             if hasattr(status.question.fields[0], 'saveas'):
                 id_index = 0
                 pairlist = list(status.selectcompute[status.question.fields[0].number])
-                if hasattr(status.question.fields[0], 'shuffle') and status.question.fields[0].shuffle:
+                using_opt_groups = all(['group' in pair for pair in pairlist])
+                using_shuffle = hasattr(status.question.fields[0], 'shuffle') and status.question.fields[0].shuffle
+                if using_opt_groups:
+                    if using_shuffle:
+                        pairlist = sorted(pairlist, key=lambda p: p.get('group') + random_string(10))
+                    else:
+                        # stable sort: keep group items in the same relative order
+                        pairlist = sorted(pairlist, key=lambda p: p.get('group')) 
+                elif using_shuffle:
                     random.shuffle(pairlist)
                 found_default = False
+                last_group = None
                 for pair in pairlist:
+                    if using_opt_groups and pair.get('group') != last_group:
+                        if last_group != None:
+                            the_options += '</optgroup>'
+                        pair_group = pair.get('group')
+                        inner_fieldlist.append(f'<optgroup label="{pair_group}">')
+                        last_group = pair_group
                     if 'image' in pair:
                         the_icon = icon_html(status, pair['image']) + ' '
                     else:
@@ -2183,25 +2198,31 @@ def input_for(status, field, wide=False, embedded=False):
     if 'css class' in status.extras and field.number in status.extras['css class']:
         extra_class += ' ' + clean_whitespace(status.extras['css class'][field.number])
     if hasattr(field, 'choicetype'):
-        # logmessage("In a choicetype where field datatype is " + field.datatype)
-        # if hasattr(field, 'inputtype'):
-        #     logmessage("inputtype is" + field.inputtype)
-        # else:
-        #     logmessage("No inputtype")
+        logmessage("In a choicetype where field datatype is " + field.datatype)
+        logmessage(field.choicetype)
+        if hasattr(field, 'inputtype'):
+            logmessage("inputtype is" + field.inputtype)
+        else:
+            logmessage("No inputtype")
         if field.choicetype in ['compute', 'manual']:
             pairlist = list(status.selectcompute[field.number])
         else:
             raise Exception("Unknown choicetype " + field.choicetype)
+        logmessage(f'pairlist: {pairlist}')
         using_opt_groups = all(['group' in pair for pair in pairlist])
+        logmessage(f'using_opt_groups: {using_opt_groups}')
         using_shuffle = hasattr(field, 'shuffle') and field.shuffle
+        logmessage(f'using_shuffle: {using_shuffle}')
         if using_opt_groups:
             # Using optgroups, each option has an associated group
             if using_shuffle:
-                pairlist = sorted(pairlist, key=lambda p: p.get('group'))
-            else:
                 pairlist = sorted(pairlist, key=lambda p: p.get('group') + random_string(10))
+            else:
+                # stable sort: keep group items in the same relative order
+                pairlist = sorted(pairlist, key=lambda p: p.get('group'))
         elif using_shuffle:
             random.shuffle(pairlist)
+        logmessage(f'new pairlist: {pairlist}')
 
         if field.datatype in ['multiselect', 'object_multiselect']:
             if field.datatype == 'object_multiselect':
@@ -2228,9 +2249,9 @@ def input_for(status, field, wide=False, embedded=False):
             last_group = None
             for pair in pairlist:
                 if using_opt_groups and pair.get('group') != last_group:
-                    pair_group = pair.get('group')
                     if last_group != None:
                         the_options += '</optgroup>'
+                    pair_group = pair.get('group')
                     the_options += f'<optgroup label="{pair_group}">'
                     last_group = pair_group
                 if isinstance(pair['key'], str):
@@ -2459,13 +2480,25 @@ def input_for(status, field, wide=False, embedded=False):
             #logmessage("defaultvalue_is_printable is " + repr(defaultvalue_is_printable))
             found_default = False
             other_options = ''
+            last_group = None
             for pair in pairlist:
-                #logmessage("Considering " + repr(pair['key']) + " and " + repr(pair['label']))
+                if using_opt_groups and pair.get('group') != last_group:
+                    if last_group != None:
+                        other_options += '</optgroup>'
+                    pair_group = pair.get('group')
+                    other_options += f'<optgroup label="{pair_group}">'
+                    last_group = pair_group
                 other_options += '<option value=' + fix_double_quote(str(pair['key']))
-                if ('default' in pair and pair['default']) or (defaultvalue is not None and isinstance(defaultvalue, (str, int, bool, float)) and str(pair['key']) == defaultvalue_printable) or (defaultvalue is not None and isinstance(defaultvalue, (str, int, bool, float)) and defaultvalue_is_printable and str(pair['label']) == defaultvalue_printable) or (hasattr(field, 'datatype') and field.datatype == 'object' and defaultvalue is not None and hasattr(defaultvalue, 'instanceName') and safeid(defaultvalue.instanceName) == pair['key']) or (defaultvalue_set and defaultvalue is None and str(pair['key']) == 'None'):
+                if ('default' in pair and pair['default']) or \
+                      (defaultvalue is not None and isinstance(defaultvalue, (str, int, bool, float)) and str(pair['key']) == defaultvalue_printable) or \
+                      (defaultvalue is not None and isinstance(defaultvalue, (str, int, bool, float)) and defaultvalue_is_printable and str(pair['label']) == defaultvalue_printable) or \
+                      (hasattr(field, 'datatype') and field.datatype == 'object' and defaultvalue is not None and hasattr(defaultvalue, 'instanceName') and safeid(defaultvalue.instanceName) == pair['key']) or \
+                      (defaultvalue_set and defaultvalue is None and str(pair['key']) == 'None'):
                     other_options += ' selected="selected"'
                     found_default = True
                 other_options += '>' + markdown_to_html(str(pair['label']), status=status, escape='option', trim=True, do_terms=False) + '</option>'
+            if using_opt_groups:
+                other_options += '</optgroup>'
             if (not status.extras['required'][field.number]) or (not found_default):
                 output += first_option
             output += other_options

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -10244,6 +10244,7 @@ def index(action_argument=None, refer=None):
             }
           }
         });
+        // iOS will truncate text in `select` options. Adding an empty optgroup fixes that
         if (navigator.userAgent.match(/(iPad|iPhone|iPod touch);/i)) {
           var selects = document.querySelectorAll("select");
           for (var i = 0; i < selects.length; i++){


### PR DESCRIPTION
Allows interview authors to specify optgroups for options. Helps organize options in `select` tags into a single level hierarchy. It's implemented by looking for a `group` attribute in each choice, and sorting those groups in the same order that they first appear in the choices attnibute, and then inserting an `<optgroup>` tag at the beginning of each group.

The label of the `<optgroup>` tag is the same string as the "group" attribute.

A version of this has been running in production for a few weeks now, and this particular code has been tested with:
* a single `dropdown` attribute, without the `fields` attribute
* manually specifying choices
* choices from code

If the `shuffle` attribute is enabled, each of the groups are shuffled around, and the items within each group is shuffled.

More info on optgroups in [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup).