### PR TITLE
Combined logic for showifdef, value, and defined

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -21,6 +21,8 @@ import tzlocal
 import us
 import pycountry
 import markdown
+from enum import Enum
+from typing import List
 from mdx_smartypants import SmartypantsExt
 import nltk
 try:
@@ -3853,6 +3855,40 @@ class lister(ast.NodeVisitor):
     def visit_Subscript(self, node):
         self.stack.append(['index', re.sub(r'\n', '', astunparse.unparse(node.slice))])
         ast.NodeVisitor.generic_visit(self, node)
+    def visit_BinOp(self, node):
+        self.stack.append(['binop', re.sub(r'\n', '', astunparse.unparse(node))]) 
+        ast.NodeVisitor.generic_visit(self, node)
+    def visit_Constant(self, node):
+        return
+
+def str_for_op(op):
+    if isinstance(op, ast.Add):
+      return '+'
+    if isinstance(op, ast.Sub):
+      return '-'
+    if isinstance(op, ast.Mult):
+      return '*'
+    if isinstance(op, ast.Div):
+      return '/'
+    if isinstance(op, ast.FloorDiv):
+      return '//'
+    if isinstance(op, ast.Mod):
+      return '%'
+    if isinstance(op, ast.Pow):
+      return '**'
+    if isinstance(op, ast.LShift):
+      return '<<'
+    if isinstance(op, ast.RShift):
+      return '>>'
+    if isinstance(op, ast.BitOr):
+      return '|'
+    if isinstance(op, ast.BitXor):
+      return '^'
+    if isinstance(op, ast.BitAnd):
+      return '&'
+    else: # if isinstance(op, ast.BitMatMult):
+      return '@'
+
 
 def components_of(full_variable):
     node = ast.parse(full_variable, mode='eval')
@@ -3972,7 +4008,135 @@ def define(var, val):
     if '__define_val' in user_dict:
         del user_dict['__define_val']
 
-def defined(var):
+class DefCaller(Enum):
+    DEFINED = 1
+    VALUE = 2
+    SHOWIFDEF = 3
+    def is_pure(self) -> bool:
+        """The functions defined() and showifdef() don't affect the external state of the
+            interview, and are idempotent, so they are pure functions"""
+        return self == self.DEFINED or self == self.SHOWIFDEF
+    def is_predicate(self) -> bool:
+        """True if the function itself is a predicate (returns True/False)"""
+        return self == self.DEFINED
+
+def _defined_internal(var, caller:DefCaller, alt=None):
+    """Checks if a variable is defined at all in the stack. Used by defined(),
+    value(), and showifdef(). `var` is the name of the variable to check,
+    `caller` is the name of the function calling (which determines what to do
+    if the variable is found to be defined or not).
+
+    If caller = 'defined', then True/False is returned depending on if the variable is defined
+    If caller = 'value', then the actual value of the variable is returned, after asking the
+      user all of the questions necessary to answer it
+    If caller = 'showifdef', then the value if returned, but only if no questions have to be asked
+    """
+    frame = inspect.stack()[1][0]
+    components = components_of(var)
+    if len(components) == 0 or len(components[0]) < 2:
+        raise Exception("defined: variable " + repr(var) + " is not a valid variable name")
+    variable = components[0][1]
+    the_user_dict = frame.f_locals
+    failure_val = False if caller == DefCaller.DEFINED else alt
+    while variable not in the_user_dict:
+        frame = frame.f_back
+        if frame is None:
+            if caller.is_pure():
+                this_thread.probing = False
+                return failure_val
+            force_ask(variable, persistent=False)
+        if 'user_dict' in frame.f_locals:
+            the_user_dict = eval('user_dict', frame.f_locals)
+            if variable in the_user_dict:
+                break
+            else:
+                if caller.is_pure():
+                    this_thread.probing = False
+                    return failure_val
+                force_ask(variable, persistent=False)
+        else:
+            the_user_dict = frame.f_locals
+    if variable not in the_user_dict:
+        if caller.is_pure():
+            return failure_val
+        force_ask(variable, persistent=False)
+    if len(components) == 1:
+        if caller.is_predicate(): 
+            return True
+        else: 
+            return eval(variable, the_user_dict)
+
+    cum_variable = ''
+    this_thread.probing = True
+    for elem in components:
+        if elem[0] == 'name':
+            # on a new name, we re-accumulate the prev checked code from scratch
+            cum_variable = elem[1]
+            continue
+        if elem[0] == 'attr':
+            to_eval = "hasattr(" + cum_variable + ", " + repr(elem[1]) + ")"
+            cum_variable += '.' + elem[1]
+        elif elem[0] == 'index':
+            try:
+                the_index = eval(elem[1], the_user_dict)
+            except:
+                if caller.is_pure():
+                    this_thread.probing = False
+                    return failure_val
+                force_ask(elem[1], persistent=False)
+            try:
+                the_cum = eval(cum_variable, the_user_dict)
+            except:
+                if caller.is_pure():
+                    this_thread.probing = False
+                    return failure_val
+                force_ask(cum_variable, persistent=False)
+            if hasattr(the_cum, 'instanceName') and hasattr(the_cum, 'elements'):
+                var_elements = cum_variable + '.elements'
+            else:
+                var_elements = cum_variable
+
+            if isinstance(the_index, int):
+                to_eval = 'len(' + var_elements + ') > ' + str(the_index)
+            else:
+                to_eval = elem[1] + " in " + var_elements
+            cum_variable += '[' + elem[1] + ']'
+        elif elem[0] == 'binop':
+            # no easy way to check if 2 objs can be compared w/o just comparing
+            to_eval = elem[1]
+            cum_variable += elem[1]
+        try:
+            result = eval(to_eval, the_user_dict)
+        except Exception as err:
+            if caller.is_pure():
+                #logmessage("Returning False3 after " + to_eval + ": " + str(err))
+                this_thread.probing = False
+                return failure_val
+            force_ask(to_eval, persistent=False)
+        if result:
+            continue
+        if caller.is_pure():
+            return failure_val
+        force_ask(var, persistent=False)
+    if caller.is_predicate(): 
+        return True
+    else:
+        return eval(cum_variable, the_user_dict)
+
+def value(var:str):
+    """Returns the value of the variable given by the string 'var'."""
+    str(var)
+    if not isinstance(var, str):
+        raise Exception("value() must be given a string")
+    try:
+        return eval(var, {})
+    except:
+        pass
+    if re.search(r'[\(\)\n\r]|lambda:|lambda ', var):
+        raise Exception("value() is invalid: " + repr(var))
+    return _defined_internal(var, DefCaller.VALUE)
+
+def defined(var:str) -> bool:
     """Returns true if the variable has already been defined.  Otherwise, returns false."""
     str(var)
     if not isinstance(var, str):
@@ -3984,74 +4148,25 @@ def defined(var):
         return True
     except:
         pass
-    frame = inspect.stack()[1][0]
-    components = components_of(var)
-    if len(components) == 0 or len(components[0]) < 2:
-        raise Exception("defined: variable " + repr(var) + " is not a valid variable name")
-    variable = components[0][1]
-    the_user_dict = frame.f_locals
-    while variable not in the_user_dict:
-        frame = frame.f_back
-        if frame is None:
-            return False
-        if 'user_dict' in frame.f_locals:
-            the_user_dict = eval('user_dict', frame.f_locals)
-            if variable in the_user_dict:
-                break
-            else:
-                this_thread.probing = False
-                return False
-        else:
-            the_user_dict = frame.f_locals
-    if variable not in the_user_dict:
-        return False
-    if len(components) == 1:
-        return True
-    cum_variable = ''
-    this_thread.probing = True
-    for elem in components:
-        if elem[0] == 'name':
-            cum_variable += elem[1]
-            continue
-        if elem[0] == 'attr':
-            to_eval = "hasattr(" + cum_variable + ", " + repr(elem[1]) + ")"
-            cum_variable += '.' + elem[1]
-        elif elem[0] == 'index':
-            try:
-                the_index = eval(elem[1], the_user_dict)
-            except:
-                this_thread.probing = False
-                return False
-            try:
-                the_cum = eval(cum_variable, the_user_dict)
-            except:
-                #logmessage("Returning False2.5")
-                this_thread.probing = False
-                return False
-            if hasattr(the_cum, 'instanceName') and hasattr(the_cum, 'elements'):
-                if isinstance(the_index, int):
-                    to_eval = 'len(' + cum_variable + '.elements) > ' + str(the_index)
-                else:
-                    to_eval = elem[1] + " in " + cum_variable + ".elements"
-            else:
-                if isinstance(the_index, int):
-                    to_eval = 'len(' + cum_variable + ') > ' + str(the_index)
-                else:
-                    to_eval = elem[1] + " in " + cum_variable
-            cum_variable += '[' + elem[1] + ']'
-        try:
-            result = eval(to_eval, the_user_dict)
-        except Exception as err:
-            #logmessage("Returning False3 after " + to_eval + ": " + str(err))
-            this_thread.probing = False
-            return False
-        if result:
-            continue
-        #logmessage("Returning False4")
-        this_thread.probing = False
-        return False
-    this_thread.probing = False
-    return True
+    return _defined_internal(var, DefCaller.DEFINED)
+
+def showifdef(var:str, alternative=''):
+    """Returns the variable indicated by the variable name if it is
+     defined, but otherwise returns empty text, or other alternative text.
+     """
+    # A combination of the preambles of defined and value
+    str(var)
+    if not isinstance(var, str):
+        raise Exception("showifdef() must be given a string")
+    if not re.search(r'[A-Za-z][A-Za-z0-9\_]*', var):
+        raise Exception("showifdef() must be given a valid Python variable name")
+    try:
+        return eval(var, {})
+    except:
+       pass
+    if re.search(r'[\(\)\n\r]|lambda:|lambda ', var):
+        raise Exception("showifdef() is invalid: " + repr(var))
+    return _defined_internal(var, DefCaller.SHOWIFDEF, alt=alternative)
 
 def illegal_variable_name(var):
     if re.search(r'[\n\r]', var):
@@ -4064,74 +4179,6 @@ def illegal_variable_name(var):
     detector.visit(t)
     return detector.illegal
 
-def value(var):
-    """Returns the value of the variable given by the string 'var'."""
-    str(var)
-    if not isinstance(var, str):
-        raise Exception("value() must be given a string")
-    try:
-        return eval(var, {})
-    except:
-        pass
-    if re.search(r'[\(\)\n\r]|lambda:|lambda ', var):
-        raise Exception("value() is invalid: " + repr(var))
-    frame = inspect.stack()[1][0]
-    components = components_of(var)
-    if len(components) == 0 or len(components[0]) < 2:
-        raise Exception("value: variable " + repr(var) + " is not a valid variable name")
-    variable = components[0][1]
-    the_user_dict = frame.f_locals
-    while variable not in the_user_dict:
-        frame = frame.f_back
-        if frame is None:
-            force_ask(variable, persistent=False)
-        if 'user_dict' in frame.f_locals:
-            the_user_dict = eval('user_dict', frame.f_locals)
-            if variable in the_user_dict:
-                break
-            else:
-                force_ask(variable, persistent=False)
-        else:
-            the_user_dict = frame.f_locals
-    if variable not in the_user_dict:
-        force_ask(variable, persistent=False)
-    if len(components) == 1:
-        return eval(variable, the_user_dict)
-    cum_variable = ''
-    for elem in components:
-        if elem[0] == 'name':
-            if cum_variable == '':
-                cum_variable = elem[1]
-            continue
-        if elem[0] == 'attr':
-            to_eval = "hasattr(" + cum_variable + ", " + repr(elem[1]) + ")"
-            cum_variable += '.' + elem[1]
-        elif elem[0] == 'index':
-            try:
-                the_index = eval(elem[1], the_user_dict)
-            except:
-                force_ask(elem[1], persistent=False)
-            try:
-                the_cum_variable = eval(cum_variable, the_user_dict)
-            except:
-                force_ask(cum_variable, persistent=False)
-            if hasattr(the_cum_variable, 'instanceName') and hasattr(the_cum_variable, 'elements'):
-                cum_variable_elements = cum_variable + '.elements'
-            else:
-                cum_variable_elements = cum_variable
-            if isinstance(the_index, int):
-                to_eval = 'len(' + cum_variable_elements + ') > ' + str(the_index)
-            else:
-                to_eval = elem[1] + " in " + cum_variable_elements
-            cum_variable += '[' + elem[1] + ']'
-        try:
-            result = eval(to_eval, the_user_dict)
-        except:
-            force_ask(to_eval, persistent=False)
-        if result:
-            continue
-        force_ask(var, persistent=False)
-    return eval(cum_variable, the_user_dict)
 
 # def _undefine(*pargs):
 #     logmessage("called _undefine")
@@ -4530,15 +4577,6 @@ def showif(var, condition, alternative=''):
     """
     ensure_definition(var, condition, alternative)
     if condition:
-        return value(var)
-    return alternative
-
-def showifdef(var, alternative=''):
-    """Returns the variable indicated by the variable name if it is
-    defined, but otherwise returns empty text, or other alternative text.
-
-    """
-    if defined(var):
         return value(var)
     return alternative
 

--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -3861,35 +3861,6 @@ class lister(ast.NodeVisitor):
     def visit_Constant(self, node):
         return
 
-def str_for_op(op):
-    if isinstance(op, ast.Add):
-      return '+'
-    if isinstance(op, ast.Sub):
-      return '-'
-    if isinstance(op, ast.Mult):
-      return '*'
-    if isinstance(op, ast.Div):
-      return '/'
-    if isinstance(op, ast.FloorDiv):
-      return '//'
-    if isinstance(op, ast.Mod):
-      return '%'
-    if isinstance(op, ast.Pow):
-      return '**'
-    if isinstance(op, ast.LShift):
-      return '<<'
-    if isinstance(op, ast.RShift):
-      return '>>'
-    if isinstance(op, ast.BitOr):
-      return '|'
-    if isinstance(op, ast.BitXor):
-      return '^'
-    if isinstance(op, ast.BitAnd):
-      return '&'
-    else: # if isinstance(op, ast.BitMatMult):
-      return '@'
-
-
 def components_of(full_variable):
     node = ast.parse(full_variable, mode='eval')
     crawler = lister()
@@ -4026,10 +3997,11 @@ def _defined_internal(var, caller:DefCaller, alt=None):
     `caller` is the name of the function calling (which determines what to do
     if the variable is found to be defined or not).
 
-    If caller = 'defined', then True/False is returned depending on if the variable is defined
-    If caller = 'value', then the actual value of the variable is returned, after asking the
+    if caller is:
+    * DEFINED, then True/False is returned depending on if the variable is defined
+    * VALUE, then the actual value of the variable is returned, after asking the
       user all of the questions necessary to answer it
-    If caller = 'showifdef', then the value if returned, but only if no questions have to be asked
+    * SHOWIFDEF, then the value if returned, but only if no questions have to be asked
     """
     frame = inspect.stack()[1][0]
     components = components_of(var)
@@ -4037,7 +4009,7 @@ def _defined_internal(var, caller:DefCaller, alt=None):
         raise Exception("defined: variable " + repr(var) + " is not a valid variable name")
     variable = components[0][1]
     the_user_dict = frame.f_locals
-    failure_val = False if caller == DefCaller.DEFINED else alt
+    failure_val = False if caller.is_predicate() else alt
     while variable not in the_user_dict:
         frame = frame.f_back
         if frame is None:


### PR DESCRIPTION
Two changes:
* `showifdef`, `value`, and `defined` all used the `components_of` function. However, the `components_of` function doesn't handle complex nesting, just returning wrong values for some question (for example, using one variable as an index into another variable). This PR fixes that bug, and also adds support for binary operations in expressions, which is useful for `showifdef` or `value`.
* to implement the above, I combined the code for `showifdef`, `value`, and `defined`, which all have an identical function body, just with different return behaviors (`value` specifically just calls `force_ask` each time the other functions return). This change should make things a bit simpler, It also should save a small bit of compute for lots of showifs in a row that are all defined, since previously that function was repeating the same calculations twice

Open to any discussion of this, and can change things around if wanted.

Tested on the below interview, which can't be run on the current main because of a bug in value, but if you comment out `vals`, you can see the wrong results being shown on the current main.
```yaml
code: |
  a = {'hi': [1, 2, 4, 0], 'bye': {'a': 1, 'b': 2}}
  b = 'hi'
  one = 1
---
code: |
  c = 'bye'
---
code: |
  d = 'b'
---
code: |
  two = 2
---
code: | 
  a
  strs = ['a["hi"]', 'a[b]', 'a[b][a["bye"]["a"]]', 'a[b][one + 1]', 'a[b][1 + two]', 'a[c]', 'a[c][d]']
---
code: |
  defineds = [defined(st) for st in strs]
---
code: |
  showifdefs = [showifdef(st) for st in strs]
---
code: |
  showifdefs2 = [showifdef(st, 'Not there') for st in strs]
---
code: |
  vals = [value(st) for st in strs]
---
mandatory: True
question: |
  Test
subquestion: |
  ${ strs }
  
  ${ defineds }
  
  ${ showifdefs }
  
  ${ showifdefs2 }
  
  ${ vals }
```