### PR TITLE
Interview WCAG

### DIFF
--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1460,6 +1460,12 @@ def my_escape(result):
     result = amp_match.sub('&amp;', result)
     return result
 
+def no_emoji(string):
+    """Takes the emoji indicators (:emoji-here:) in terms and replaces them with open and close parenthesis.
+      Used to avoid emoji substituion later in the process inside of aria-labels.
+    """
+    return emoji_match.sub((lambda x: f"({x.group(1)} emoji)"), string)
+
 def noquote(string):
     #return json.dumps(string.replace('\n', ' ').rstrip())
     return '"' + string.replace('\n', ' ').replace('"', '&quot;').rstrip() + '"'
@@ -1467,7 +1473,7 @@ def noquote(string):
 def add_terms_mako(termname, terms, status=None, question=None):
     lower_termname = re.sub(r'\s+', ' ', termname.lower(), re.DOTALL)
     if lower_termname in terms:
-        return '<a tabindex="0" class="daterm" aria-label=' + noquote(str(termname) + ' ' + word("(term definition)")) +\
+        return '<a tabindex="0" class="daterm" aria-label=' + noquote(no_emoji(str(termname)) + ' ' + word("(term definition)")) +\
             ' data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' +\
             noquote(markdown_to_html(terms[lower_termname]['definition'].text({}),
                 trim=True, default_image_width='100%', do_terms=False, status=status, question=question
@@ -1482,7 +1488,7 @@ def add_terms(termname, terms, label=None, status=None, question=None):
         label = re.sub(r'^\|', '', label)
     lower_termname = re.sub(r'\s+', ' ', termname.lower(), re.DOTALL)
     if lower_termname in terms:
-        return '<a tabindex="0" class="daterm" aria-label=' + noquote(label + ' ' + word("(term definition)")) +\
+        return '<a tabindex="0" class="daterm" aria-label=' + noquote(no_emoji(label) + ' ' + word("(term definition)")) +\
             ' data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' +\
             noquote(markdown_to_html(terms[lower_termname]['definition'],
                 trim=True, default_image_width='100%', do_terms=False, status=status, question=question

--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1467,7 +1467,7 @@ def noquote(string):
 def add_terms_mako(termname, terms, status=None, question=None):
     lower_termname = re.sub(r'\s+', ' ', termname.lower(), re.DOTALL)
     if lower_termname in terms:
-        return '<a tabindex="0" class="daterm" aria-label=' + noquote(str(termname) + ' (term definition)') +\
+        return '<a tabindex="0" class="daterm" aria-label=' + noquote(str(termname) + ' ' + word("(term definition)")) +\
             ' data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' +\
             noquote(markdown_to_html(terms[lower_termname]['definition'].text({}),
                 trim=True, default_image_width='100%', do_terms=False, status=status, question=question
@@ -1482,7 +1482,7 @@ def add_terms(termname, terms, label=None, status=None, question=None):
         label = re.sub(r'^\|', '', label)
     lower_termname = re.sub(r'\s+', ' ', termname.lower(), re.DOTALL)
     if lower_termname in terms:
-        return '<a tabindex="0" class="daterm" aria-label=' + noquote(label + ' (term definition)') +\
+        return '<a tabindex="0" class="daterm" aria-label=' + noquote(label + ' ' + word("(term definition)")) +\
             ' data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' +\
             noquote(markdown_to_html(terms[lower_termname]['definition'],
                 trim=True, default_image_width='100%', do_terms=False, status=status, question=question

--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1493,7 +1493,6 @@ def add_terms(termname, terms, label=None, status=None, question=None):
             noquote(markdown_to_html(terms[lower_termname]['definition'],
                 trim=True, default_image_width='100%', do_terms=False, status=status, question=question
             )) + '>' + label + '</a>'
-    #logmessage(lower_termname + " is not in terms dictionary\n")
     return '[[' + termname + ']]'
 
 def audio_control(files, preload="metadata", title_text=None):

--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1467,7 +1467,11 @@ def noquote(string):
 def add_terms_mako(termname, terms, status=None, question=None):
     lower_termname = re.sub(r'\s+', ' ', termname.lower(), re.DOTALL)
     if lower_termname in terms:
-        return '<a tabindex="0" class="daterm" data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' + noquote(markdown_to_html(terms[lower_termname]['definition'].text({}), trim=True, default_image_width='100%', do_terms=False, status=status, question=question)) + '>' + str(termname) + '</a>'
+        return '<a tabindex="0" class="daterm" aria-label=' + noquote(str(termname) + ' (term definition)') +\
+            ' data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' +\
+            noquote(markdown_to_html(terms[lower_termname]['definition'].text({}),
+                trim=True, default_image_width='100%', do_terms=False, status=status, question=question
+            )) + '>' + str(termname) + '</a>'
     #logmessage(lower_termname + " is not in terms dictionary\n")
     return '[[' + termname + ']]'
 
@@ -1478,7 +1482,11 @@ def add_terms(termname, terms, label=None, status=None, question=None):
         label = re.sub(r'^\|', '', label)
     lower_termname = re.sub(r'\s+', ' ', termname.lower(), re.DOTALL)
     if lower_termname in terms:
-        return '<a tabindex="0" class="daterm" data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' + noquote(markdown_to_html(terms[lower_termname]['definition'], trim=True, default_image_width='100%', do_terms=False, status=status, question=question)) + '>' + label + '</a>'
+        return '<a tabindex="0" class="daterm" aria-label=' + noquote(label + ' (term definition)') +\
+            ' data-bs-toggle="popover" data-bs-container="body" data-bs-placement="bottom" data-bs-content=' +\
+            noquote(markdown_to_html(terms[lower_termname]['definition'],
+                trim=True, default_image_width='100%', do_terms=False, status=status, question=question
+            )) + '>' + label + '</a>'
     #logmessage(lower_termname + " is not in terms dictionary\n")
     return '[[' + termname + ']]'
 

--- a/docassemble_base/docassemble/base/standardformatter.py
+++ b/docassemble_base/docassemble/base/standardformatter.py
@@ -742,7 +742,7 @@ def as_html(status, debug, root, validation_rules, field_error, the_progress_bar
         if video_text:
             output += indent_by(video_text, 12)
         output += status.submit
-        output += '                <fieldset class="da-button-set da-field-' + status.question.question_type + '" aria-required="true">\n                  <legend class="visually-hidden">' + word('Press one of the following buttons:') + '</legend>'
+        output += '                <fieldset class="da-button-set da-field-' + status.question.question_type + '">\n                  <legend class="visually-hidden">' + word('Press one of the following buttons:') + '</legend>'
         output += back_button + additional_buttons_before + '\n                  <button class="btn ' + BUTTON_STYLE + BUTTON_COLOR_YES + ' ' + BUTTON_CLASS + '" name="' + escape_id(status.question.fields[0].saveas) + '" type="submit" value="True">' + status.question.yes() + '</button>\n                  <button class="btn ' + BUTTON_STYLE + BUTTON_COLOR_NO + ' ' + BUTTON_CLASS + '" name="' + escape_id(status.question.fields[0].saveas) + '" type="submit" value="False">' + status.question.no() + '</button>'
         if status.question.question_type == 'yesnomaybe':
             output += '\n                  <button class="btn ' + BUTTON_STYLE + BUTTON_COLOR_MAYBE + ' ' + BUTTON_CLASS + '" name="' + escape_id(status.question.fields[0].saveas) + '" type="submit" value="None">' + markdown_to_html(status.question.maybe(), trim=True, do_terms=False, status=status) + '</button>'
@@ -1447,7 +1447,7 @@ def as_html(status, debug, root, validation_rules, field_error, the_progress_bar
         if status.question.question_variety in ["radio", "dropdown", "combobox"]:
             if status.question.question_variety == "radio":
                 verb = 'check'
-                output += '                <fieldset class="da-field-' + status.question.question_variety +'" aria-required="true">\n                  <legend class="visually-hidden">' + word("Choices:") + "</legend>\n"
+                output += '                <fieldset class="da-field-' + status.question.question_variety +'">\n                  <legend class="visually-hidden">' + word("Choices (choose one):") + "</legend>\n"
             else:
                 verb = 'select'
                 if status.question.question_variety == "dropdown":
@@ -2309,7 +2309,11 @@ def input_for(status, field, wide=False, embedded=False):
             if embedded:
                 output += '<span class="da-embed-checkbox-wrapper">'
             else:
-                output += '<fieldset class="da-field-checkboxes" role="group"' + req_aria + '><legend class="visually-hidden">' + word('Checkboxes:') + '</legend>'
+                if req_aria:
+                  legend_text = 'Checkboxes (select at least one):'
+                else:
+                  legend_text = 'Checkboxes:'
+                output += '<fieldset class="da-field-checkboxes" role="group"><legend class="visually-hidden">' + word(legend_text) + '</legend>'
             for pair in pairlist:
                 if 'image' in pair:
                     the_icon = icon_html(status, pair['image']) + ' '

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -2973,7 +2973,7 @@ def make_navbar(status, steps, show_login, chat_info, debug_mode, index_params, 
     source_message = word("Information for the developer")
     if debug_mode:
         source_button = '<div class="nav-item navbar-nav d-none d-md-block"><button class="btn btn-link nav-link da-no-outline" title=' + json.dumps(source_message) + ' id="dasourcetoggle" data-bs-toggle="collapse" data-bs-target="#dasource"><i class="fas fa-code"></i></button></div>'
-        source_menu_item = '<a class="dropdown-item d-block d-md-none navbar" title=' + json.dumps(source_message) + ' id="dasourcetogglemenu" href="#dasource" data-bs-toggle="collapse" aria-expanded="false" aria-controls="source">' + word('Source') + '</a>'
+        source_menu_item = '<a class="dropdown-item d-block d-md-none navbar" title=' + json.dumps(source_message) + ' href="#dasource" data-bs-toggle="collapse" aria-expanded="false" aria-controls="source">' + word('Source') + '</a>'
     else:
         source_button = ''
         source_menu_item = ''

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -2938,7 +2938,7 @@ def make_navbar(status, steps, show_login, chat_info, debug_mode, index_params, 
 """
         else:
             navbar += """\
-        <form style="display: inline-block" id="dabackbutton" method="POST" action=""" + json.dumps(url_for('index', **index_params)) + """><input type="hidden" name="csrf_token" value=""" + '"' + generate_csrf() + '"' + """/><input type="hidden" name="_back_one" value="1"/></form>
+        <form hidden style="display: inline-block" id="dabackbutton" method="POST" action=""" + json.dumps(url_for('index', **index_params)) + """><input type="hidden" name="csrf_token" value=""" + '"' + generate_csrf() + '"' + """/><input type="hidden" name="_back_one" value="1"/></form>
 """
     if status.title_url:
         if str(status.title_url_opens_in_other_window) == 'False':
@@ -2972,20 +2972,22 @@ def make_navbar(status, steps, show_login, chat_info, debug_mode, index_params, 
     chat_sr = word("Live chat")
     source_message = word("Information for the developer")
     if debug_mode:
-        source_button = '<li class="nav-item d-none d-md-block"><button class="btn btn-link nav-link da-no-outline" title=' + json.dumps(source_message) + ' id="dasourcetoggle" data-bs-toggle="collapse" data-bs-target="#dasource"><i class="fas fa-code"></i></button></li>'
-        source_menu_item = '<a class="dropdown-item d-block d-md-none" title=' + json.dumps(source_message) + ' id="dasourcetoggle" href="#dasource" data-bs-toggle="collapse" aria-expanded="false" aria-controls="source">' + word('Source') + '</a>'
+        source_button = '<div class="nav-item navbar-nav d-none d-md-block"><button class="btn btn-link nav-link da-no-outline" title=' + json.dumps(source_message) + ' id="dasourcetoggle" data-bs-toggle="collapse" data-bs-target="#dasource"><i class="fas fa-code"></i></button></div>'
+        source_menu_item = '<a class="dropdown-item d-block d-md-none navbar" title=' + json.dumps(source_message) + ' id="dasourcetogglemenu" href="#dasource" data-bs-toggle="collapse" aria-expanded="false" aria-controls="source">' + word('Source') + '</a>'
     else:
         source_button = ''
         source_menu_item = ''
-    navbar += '        <ul class="nav navbar-nav damynavbar-right" role="tablist">' + source_button + '<li class="nav-item dainvisible" role="presentation"><button class="btn btn-link nav-link active da-no-outline" id="daquestionlabel" data-bs-toggle="tab" data-bs-target="#daquestion">' + word('Question') + '</button></li>'
+    hidden_question_button = '<div hidden class="nav-item dainvisible" role="presentation"><button class="btn btn-link nav-link active da-no-outline" id="daquestionlabel" data-bs-toggle="tab" data-bs-target="#daquestion">' + word('Question') + '</button></div>'
+    navbar += '        ' + source_button + hidden_question_button + '<ul id="nav-bar-tab-list" class="nav navbar-nav damynavbar-right" role="tablist">'
     if len(status.interviewHelpText) > 0 or (len(status.helpText) > 0 and not status.question.interview.question_help_button):
         if status.question.helptext is None or status.question.interview.question_help_button:
-            navbar += '<li class="nav-item" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline" data-bs-target="#dahelp" data-bs-toggle="tab" id="dahelptoggle" title=' + json.dumps(help_message) + '>' + help_label + '</button></li>'
+            navbar += '<li class="nav-item" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline" data-bs-target="#dahelp" data-bs-toggle="tab" role="tab" id="dahelptoggle" title=' + json.dumps(help_message) + '>' + help_label + '</button></li>'
         else:
-            navbar += '<li class="nav-item" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline daactivetext" data-bs-target="#dahelp" data-bs-toggle="tab" id="dahelptoggle" title=' + json.dumps(extra_help_message) + '>' + help_label + ' <i class="fas fa-star"></i></button></li>'
+            navbar += '<li class="nav-item" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline daactivetext" data-bs-target="#dahelp" data-bs-toggle="tab" role="tab" id="dahelptoggle" title=' + json.dumps(extra_help_message) + '>' + help_label + ' <i class="fas fa-star"></i></button></li>'
     else:
-        navbar += '<li class="nav-item dainvisible" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline" id="dahelptoggle" data-bs-target="#dahelp" data-bs-toggle="tab">' + word('Help') + '</button></li>'
-    navbar += '<li class="nav-item dainvisible" id="daPhoneAvailable"><button data-bs-target="#dahelp" data-bs-toggle="tab" title=' + json.dumps(phone_message) + ' class="btn btn-link nav-link dapointer dahelptrigger da-no-outline"><i class="fas fa-phone da-chat-active"></i><span class="visually-hidden">' + phone_sr + '</span></button></li><li class="nav-item dainvisible" id="daChatAvailable"><button data-bs-target="#dahelp" data-bs-toggle="tab" class="btn btn-link nav-link dapointer dahelptrigger da-no-outline"><i class="fas fa-comment-alt"></i><span class="visually-hidden">' + chat_sr + '</span></button></li></ul>'
+        navbar += '<li hidden class="nav-item dainvisible" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline" id="dahelptoggle" data-bs-target="#dahelp" data-bs-toggle="tab" role="tab">' + word('Help') + '</button></li>'
+    navbar += '<li hidden class="nav-item dainvisible" id="daPhoneAvailable"><button data-bs-target="#dahelp" data-bs-toggle="tab" role="tab" title=' + json.dumps(phone_message) + ' class="btn btn-link nav-link dapointer dahelptrigger da-no-outline"><i class="fas fa-phone da-chat-active"></i><span class="visually-hidden">' + phone_sr + '</span></button></li>' + \
+              '<li class="nav-item dainvisible" id="daChatAvailable"><button data-bs-target="#dahelp" data-bs-toggle="tab" class="btn btn-link nav-link dapointer dahelptrigger da-no-outline"><i class="fas fa-comment-alt"></i><span class="visually-hidden">' + chat_sr + '</span></button></li></ul>'
     navbar += """
         <button id="damobile-toggler" type="button" class="navbar-toggler ms-auto" data-bs-toggle="collapse" data-bs-target="#danavbar-collapse">
           <span class="navbar-toggler-icon"></span><span class="visually-hidden">""" + word("Display the menu") + """</span>
@@ -9643,6 +9645,14 @@ def index(action_argument=None, refer=None):
           $("#daSend").prop('disabled', false);
           daInformAbout('chat');
         }
+        var anyTabs = $("#daChatAvailable").is(":visible") 
+            || $("daPhoneAvailable").is(":visible") 
+            || $("#dahelptoggle").is(":visible");
+        if (anyTabs) {
+          $("#nav-bar-tab-list").removeClass("dainvisible");
+        } else {
+          $("#nav-bar-tab-list").addClass("dainvisible");
+        }
       }
       function daChatLogCallback(data){
         if (data.action && data.action == 'reload'){
@@ -9822,6 +9832,14 @@ def index(action_argument=None, refer=None):
               daInitializeSocket();
             }
           }
+        }
+        var anyTabs = $("#daChatAvailable").is(":visible") 
+            || $("daPhoneAvailable").is(":visible") 
+            || $("#dahelptoggle").is(":visible");
+        if (anyTabs) {
+          $("#nav-bar-tab-list").removeClass("dainvisible");
+        } else {
+          $("#nav-bar-tab-list").addClass("dainvisible");
         }
       }
       function daCheckoutCallback(data){
@@ -11129,6 +11147,14 @@ def index(action_argument=None, refer=None):
         }
         if (daUsingSegment){
           daSegmentEvent();
+        }
+        var anyTabs = $("#daChatAvailable").is(":visible") 
+            || $("daPhoneAvailable").is(":visible") 
+            || $("#dahelptoggle").is(":visible");
+        if (anyTabs) {
+          $("#nav-bar-tab-list").removeClass("dainvisible");
+        } else {
+          $("#nav-bar-tab-list").addClass("dainvisible");
         }
         $(document).trigger('daPageLoad');
       }

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -2977,8 +2977,8 @@ def make_navbar(status, steps, show_login, chat_info, debug_mode, index_params, 
     else:
         source_button = ''
         source_menu_item = ''
-    hidden_question_button = '<div hidden class="nav-item dainvisible" role="presentation"><button class="btn btn-link nav-link active da-no-outline" id="daquestionlabel" data-bs-toggle="tab" data-bs-target="#daquestion">' + word('Question') + '</button></div>'
-    navbar += '        ' + source_button + hidden_question_button + '<ul id="nav-bar-tab-list" class="nav navbar-nav damynavbar-right" role="tablist">'
+    hidden_question_button = '<li class="nav-item dainvisible"><button class="btn btn-link nav-link active da-no-outline" id="daquestionlabel" data-bs-toggle="tab" data-bs-target="#daquestion">' + word('Question') + '</button></li>'
+    navbar += '        ' + source_button + '<ul id="nav-bar-tab-list" class="nav navbar-nav damynavbar-right" role="tablist">' + hidden_question_button
     if len(status.interviewHelpText) > 0 or (len(status.helpText) > 0 and not status.question.interview.question_help_button):
         if status.question.helptext is None or status.question.interview.question_help_button:
             navbar += '<li class="nav-item" role="presentation"><button class="btn btn-link nav-link dahelptrigger da-no-outline" data-bs-target="#dahelp" data-bs-toggle="tab" role="tab" id="dahelptoggle" title=' + json.dumps(help_message) + '>' + help_label + '</button></li>'
@@ -8208,6 +8208,18 @@ def index(action_argument=None, refer=None):
       function daatob(str) {
         return window.atob(str);
       }
+      function hideTablist() {
+        var anyTabs = $("#daChatAvailable").is(":visible") 
+            || $("daPhoneAvailable").is(":visible") 
+            || $("#dahelptoggle").is(":visible");
+        if (anyTabs) {
+          $("#nav-bar-tab-list").removeClass("dainvisible");
+          $("#daquestionlabel").parent().removeClass("dainvisible");
+        } else {
+          $("#nav-bar-tab-list").addClass("dainvisible");
+          $("#daquestionlabel").parent().addClass("dainvisible");
+        }
+      }
       function getFields(){
         var allFields = [];
         for (var rawFieldName in daVarLookup){
@@ -9645,14 +9657,7 @@ def index(action_argument=None, refer=None):
           $("#daSend").prop('disabled', false);
           daInformAbout('chat');
         }
-        var anyTabs = $("#daChatAvailable").is(":visible") 
-            || $("daPhoneAvailable").is(":visible") 
-            || $("#dahelptoggle").is(":visible");
-        if (anyTabs) {
-          $("#nav-bar-tab-list").removeClass("dainvisible");
-        } else {
-          $("#nav-bar-tab-list").addClass("dainvisible");
-        }
+        hideTablist();
       }
       function daChatLogCallback(data){
         if (data.action && data.action == 'reload'){
@@ -9833,14 +9838,7 @@ def index(action_argument=None, refer=None):
             }
           }
         }
-        var anyTabs = $("#daChatAvailable").is(":visible") 
-            || $("daPhoneAvailable").is(":visible") 
-            || $("#dahelptoggle").is(":visible");
-        if (anyTabs) {
-          $("#nav-bar-tab-list").removeClass("dainvisible");
-        } else {
-          $("#nav-bar-tab-list").addClass("dainvisible");
-        }
+        hideTablist();
       }
       function daCheckoutCallback(data){
       }
@@ -11148,14 +11146,7 @@ def index(action_argument=None, refer=None):
         if (daUsingSegment){
           daSegmentEvent();
         }
-        var anyTabs = $("#daChatAvailable").is(":visible") 
-            || $("daPhoneAvailable").is(":visible") 
-            || $("#dahelptoggle").is(":visible");
-        if (anyTabs) {
-          $("#nav-bar-tab-list").removeClass("dainvisible");
-        } else {
-          $("#nav-bar-tab-list").addClass("dainvisible");
-        }
+        hideTablist();
         $(document).trigger('daPageLoad');
       }
       $(document).ready(function(){

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -2844,7 +2844,7 @@ def progress_bar(progress, interview):
         percentage = str(int(progress)) + '%'
     else:
         percentage = ''
-    return '<div class="progress mt-2"><div class="progress-bar" role="progressbar" aria-valuenow="' + str(progress) + '" aria-valuemin="0" aria-valuemax="100" style="width: ' + str(progress) + '%;">' + percentage + '</div></div>\n'
+    return '<div class="progress mt-2"><div class="progress-bar" aria-label="Interview Progress" role="progressbar" aria-valuenow="' + str(progress) + '" aria-valuemin="0" aria-valuemax="100" style="width: ' + str(progress) + '%;">' + percentage + '</div></div>\n'
 
 def get_unique_name(filename, secret):
     nowtime = datetime.datetime.utcnow()

--- a/docassemble_webapp/docassemble/webapp/templates/pages/interviews.html
+++ b/docassemble_webapp/docassemble/webapp/templates/pages/interviews.html
@@ -5,7 +5,7 @@
 {%- set extra_js = get_part('interview page extra javascript') %}
 {%- extends 'flask_user/public_base.html' %}
 {%- block content %}
-            <h1 class="da-page-header dainterviewpage">{{ get_part('interview page heading', word('Resume an interview')) }}</h1>
+            <h1 class="da-page-header dainterviewpage h3">{{ get_part('interview page heading', word('Resume an interview')) }}</h1>
 {{ get_part('interview page pre') }}
             {%- if tag %}
             <p>

--- a/docassemble_webapp/docassemble/webapp/templates/pages/interviews.html
+++ b/docassemble_webapp/docassemble/webapp/templates/pages/interviews.html
@@ -5,7 +5,7 @@
 {%- set extra_js = get_part('interview page extra javascript') %}
 {%- extends 'flask_user/public_base.html' %}
 {%- block content %}
-            <h3 class="da-page-header dainterviewpage">{{ get_part('interview page heading', word('Resume an interview')) }}</h3>
+            <h1 class="da-page-header dainterviewpage">{{ get_part('interview page heading', word('Resume an interview')) }}</h1>
 {{ get_part('interview page pre') }}
             {%- if tag %}
             <p>

--- a/docassemble_webapp/docassemble/webapp/templates/pages/update_package.html
+++ b/docassemble_webapp/docassemble/webapp/templates/pages/update_package.html
@@ -3,10 +3,9 @@
 {% block content %}
 {% from "base_templates/form_macros.html" import render_field, render_file_field, render_select_field, render_submit_field, render_checkbox_field with context %}
 
-<h1>{{ word('Package Management') }}</h1>
 
 {%- if allowed_to_upgrade %}
-<h2>{{ word('Upgrade docassemble') }}</h2>
+<h1 class="h2">{{ word('Upgrade docassemble') }}</h1>
 <p class="h6">{{ version }}</p>
 
 <div>
@@ -18,12 +17,12 @@
 
 <form action="{{ url_for('update_package') }}" method="POST" class="form" role="form" enctype="multipart/form-data">
   {{ form.hidden_tag() }}
-  <h3>{{ word('You can provide a:') }}</h3>
+  <h2 class="h4">{{ word('You can provide a:') }}</h2>
   {{ render_field(form.giturl, placeholder='https://github.com/username/packagename') }}
   {{ render_select_field(form.gitbranch) }}
-  <h3>{{ word('Or you can upload a:') }}</h3>
+  <h2 class="h4">{{ word('Or you can upload a:') }}</h2>
   {{ render_file_field(form.zipfile) }}
-  <h3>{{ word('Or you can specify a:') }}</h3>
+  <h2 class="h4">{{ word('Or you can specify a:') }}</h2>
   {{ render_field(form.pippackage) }}
   {{ render_submit_field(form.submit) }}
 </form>

--- a/docassemble_webapp/docassemble/webapp/templates/pages/update_package.html
+++ b/docassemble_webapp/docassemble/webapp/templates/pages/update_package.html
@@ -3,6 +3,8 @@
 {% block content %}
 {% from "base_templates/form_macros.html" import render_field, render_file_field, render_select_field, render_submit_field, render_checkbox_field with context %}
 
+<h1>{{ word('Package Management') }}</h1>
+
 {%- if allowed_to_upgrade %}
 <h2>{{ word('Upgrade docassemble') }}</h2>
 <p class="h6">{{ version }}</p>
@@ -16,12 +18,12 @@
 
 <form action="{{ url_for('update_package') }}" method="POST" class="form" role="form" enctype="multipart/form-data">
   {{ form.hidden_tag() }}
-  <h4>{{ word('You can provide a:') }}</h4>
+  <h3>{{ word('You can provide a:') }}</h3>
   {{ render_field(form.giturl, placeholder='https://github.com/username/packagename') }}
   {{ render_select_field(form.gitbranch) }}
-  <h4>{{ word('Or you can upload a:') }}</h4>
+  <h3>{{ word('Or you can upload a:') }}</h3>
   {{ render_file_field(form.zipfile) }}
-  <h4>{{ word('Or you can specify a:') }}</h4>
+  <h3>{{ word('Or you can specify a:') }}</h3>
   {{ render_field(form.pippackage) }}
   {{ render_submit_field(form.submit) }}
 </form>

--- a/docassemble_webapp/docassemble/webapp/templates/pages/update_package.html
+++ b/docassemble_webapp/docassemble/webapp/templates/pages/update_package.html
@@ -17,12 +17,12 @@
 
 <form action="{{ url_for('update_package') }}" method="POST" class="form" role="form" enctype="multipart/form-data">
   {{ form.hidden_tag() }}
-  <h2 class="h4">{{ word('You can provide a:') }}</h2>
+  <h3 class="h4">{{ word('You can provide a:') }}</h2>
   {{ render_field(form.giturl, placeholder='https://github.com/username/packagename') }}
   {{ render_select_field(form.gitbranch) }}
-  <h2 class="h4">{{ word('Or you can upload a:') }}</h2>
+  <h3 class="h4">{{ word('Or you can upload a:') }}</h2>
   {{ render_file_field(form.zipfile) }}
-  <h2 class="h4">{{ word('Or you can specify a:') }}</h2>
+  <h3 class="h4">{{ word('Or you can specify a:') }}</h2>
   {{ render_field(form.pippackage) }}
   {{ render_submit_field(form.submit) }}
 </form>


### PR DESCRIPTION
I have been doing an accessibility audit for a docassemble interview, and these are some changes needed to be made in DA core to make the interview accessible. Possibly more to come, but there were present on most every page in the nav bar.

* added the tab role to the help/question tablist in the banner
* moved source and question tabs out of the tab list, just regular divs
  They aren't really tabs, as the ARIA definition of tabs are panels
  where only one displays at a time. Changed some CSS classes to make sure they display the same.
* hide the tab list element if empty (no help, chat, or phone). Elements with the role "tablist" are assumed to always have children, so if there aren't any children, we should remove it
* use the semantic "hidden" attribute just to make things a little clearer. (note: "aria-hidden" or "display: none" are fine for accessibility purposes)

Non interview changes:
* header tags need to start with 1 and go down, not skipping anything. I only checked the package management page and default interview pages here. Didn't change the CSS to make the headings the same size.

Used info from https://github.com/forsti0506/a11y-sitechecker and https://github.com/squizlabs/HTML_CodeSniffer (though Code Sniffer does have some false violations, thinking that elements that are actually hidden aren't). 