### PR TITLE
Make ghostscript handle PDF/A colorspace correctly

### DIFF
--- a/docassemble_base/docassemble/base/pdfa.py
+++ b/docassemble_base/docassemble/base/pdfa.py
@@ -7,7 +7,7 @@ from docassemble.base.error import DAError
 def pdf_to_pdfa(filename):
     outfile = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
     directory = tempfile.mkdtemp()
-    commands = ['gs', '-dPDFA', '-dBATCH', '-dNOPAUSE', '-sProcessColorModel=DeviceCMYK', '-sDEVICE=pdfwrite', '-sPDFACompatibilityPolicy=1', '-sOutputFile=' + outfile.name, filename]
+    commands = ['gs', '-dPDFA', '-dBATCH', '-dNOPAUSE', '-sColorConversionStrategy=UseDeviceIndependentColor', '-sProcessColorModel=DeviceCMYK', '-sDEVICE=pdfwrite', '-sPDFACompatibilityPolicy=1', '-sOutputFile=' + outfile.name, filename]
     try:
         output = subprocess.check_output(commands, cwd=directory, stderr=subprocess.STDOUT).decode()
     except subprocess.CalledProcessError as err:


### PR DESCRIPTION
Previously, if you tried to verify files generated by pdf_to_pdfa in a verifier (like https://tools.pdfforge.org/validate-pdfa), you would get errors relating to the lack of an OutputIntent object (ISO 19005-1:2005, Clause 6.2.3). The info in https://stackoverflow.com/a/56459053/11416267 and https://www.ghostscript.com/doc/current/VectorDevices.htm#PDFA suggested that `-sColorConversionStrategy=UseDeviceIndependentColor` be added, which corrects those validator errors, and lets the output be properly verified as PDF/A-1b.

Test code:
```yaml
---
objects:
  my_file: DAStaticFile.using(filename='lt1-pullout-10-getting-organized.pdf')
---
mandatory: True
question: |
  Here is your document.
subquestion: |
  ${ pdf_concatenate(my_file, pdfa=True)}
```

The verification was done on the below PDF (should be added to the static folder for the above test).
[lt1-pullout-10-getting-organized.pdf](https://github.com/jhpyle/docassemble/files/8628500/lt1-pullout-10-getting-organized.pdf)
 
Checked on https://tools.pdfforge.org/validate-pdfa and https://bfo.com/blog/2017/11/08/verify_pdfa_online/ (specifically for PDF/A-1b). 