### PR TITLE
Fix incorrect function reference

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -25581,7 +25581,7 @@ def set_session_variables(yaml_filename, session_id, variables, secret=None, ret
             release_lock(session_id, yaml_filename)
         raise Exception("Unable to obtain interview dictionary.")
     if process_objects:
-        variables = transform_json_data(variables)
+        variables = transform_json_variables(variables)
     pre_assembly_necessary = False
     for key, val in variables.items():
         if contains_volatile.search(key):


### PR DESCRIPTION
Caught with pylance -- it looks like `transform_json_variables()` is the correct function name