### PR TITLE
Changed all links to bootstrap stuff to bootstrap 5.0

### DIFF
--- a/_docs/accessibility.md
+++ b/_docs/accessibility.md
@@ -25,7 +25,7 @@ for persons with disabilities, including:
   tag that includes [alt text].  The [Markdown] syntax for including
   images supports [alt text].
 
-The **docassemble** user interface is built on [Bootstrap 4.0], which
+The **docassemble** user interface is built on [Bootstrap 5.0], which
 has [accessibility features and limitations].  The default Bootstrap
 color scheme does not have sufficient contrast to meet the [WCAG]
 guidelines.  You may want to create your own [Bootstrap theme] with
@@ -62,10 +62,10 @@ may be some accessibility limitations in **docassemble**.  If you
 identify any, create a [GitHub issue].
 
 [GitHub issue]: https://github.com/jhpyle/docassemble/issues
-[Bootstrap theme]: https://pikock.github.io/bootstrap-magic/app/#!/editor
+[Bootstrap theme]: https://bootstrap.build/app 
 [WCAG]: https://www.w3.org/WAI/standards-guidelines/wcag/
-[Bootstrap 4.0]: https://getbootstrap.com/docs/4.0/getting-started/introduction/
-[accessibility features and limitations]: https://getbootstrap.com/docs/4.0/getting-started/accessibility/
+[Bootstrap 5.0]: https://getbootstrap.com/docs/5.0/getting-started/introduction/
+[accessibility features and limitations]: https://getbootstrap.com/docs/5.0/getting-started/accessibility/
 [HTML]: https://en.wikipedia.org/wiki/HTML
 [label tags]: https://www.w3schools.com/tags/tag_label.asp
 [title attributes]: https://www.w3schools.com/tags/att_title.asp

--- a/_docs/config.md
+++ b/_docs/config.md
@@ -880,7 +880,7 @@ bootstrap theme: docassemble.demo:data/static/lumen.min.css
 You can also refer to files on the internet:
 
 {% highlight yaml %}
-bootstrap theme: https://bootswatch.com/4/minty/bootstrap.min.css
+bootstrap theme: https://bootswatch.com/5/minty/bootstrap.min.css
 {% endhighlight %}
 
 There are many alternative [Bootstrap] themes available on
@@ -5612,7 +5612,7 @@ and Facebook API keys.
 [Slack]: {{ site.slackurl }}
 [`geocoder service`]: #geocoder service
 [primary key]: https://docs.microsoft.com/en-us/azure/azure-maps/how-to-manage-authentication#view-authentication-details
-[Bootstrap colors]: https://getbootstrap.com/docs/4.0/components/buttons/#examples
+[Bootstrap colors]: https://getbootstrap.com/docs/5.0/components/buttons/#examples
 [`button colors`]: #button colors
 [Bootstrap theme]: #bootstrap theme
 [`allow embedding`]: #allow embedding

--- a/_docs/functions.md
+++ b/_docs/functions.md
@@ -8008,7 +8008,7 @@ $(document).on('daPageLoad', function(){
 [User-Agent header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
 [Accept-Language header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
 [Bootstrap]: https://en.wikipedia.org/wiki/Bootstrap_%28front-end_framework%29
-[Bootstrap documentation]: https://getbootstrap.com/docs/4.0/getting-started/introduction/
+[Bootstrap documentation]: https://getbootstrap.com/docs/5.0/getting-started/introduction/
 [`check in` feature]: {{ site.baseurl }}/docs/background.html#check in
 [Amazon S3]: https://aws.amazon.com/s3/
 [e-mail to interview]: {{ site.baseurl }}/docs/background.html#email
@@ -8084,7 +8084,7 @@ $(document).on('daPageLoad', function(){
 [PDF/A]: https://en.wikipedia.org/wiki/PDF/A
 [`console.log` JavaScript function]: https://developer.mozilla.org/en-US/docs/Web/API/Console/log
 [`eval` JavaScript function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
-[Bootstrap alert]: https://getbootstrap.com/docs/4.0/components/alerts/
+[Bootstrap alert]: https://getbootstrap.com/docs/5.0/components/alerts/
 [`flash()`]: #flash
 [Google API key]: {{ site.baseurl }}/docs/config.html#google
 [`google`]: {{ site.baseurl }}/docs/config.html#google

--- a/_docs/initial.md
+++ b/_docs/initial.md
@@ -2410,7 +2410,7 @@ features:
 This will cause the web application to run the JavaScript for the
 `ssn` and `iso639language` custom data types.
 
-[Bootstrap popover feature]: https://getbootstrap.com/docs/4.0/components/popovers/
+[Bootstrap popover feature]: https://getbootstrap.com/docs/5.0/components/popovers/
 [catchall questions]: {{ site.baseurl }}/docs/fields.html#catchall
 [infinite loop protection]: {{ site.baseurl }}/docs/config.html#loop limit
 [ending screen]: {{ site.baseurl }}/docs/questions.html#ending screens
@@ -2604,8 +2604,8 @@ This will cause the web application to run the JavaScript for the
 [`session_tags()`]: {{ site.baseurl }}/docs/functions.html#session_tags
 [interview]: {{ site.baseurl }}/docs/interviews.html
 [section on questions]: {{ site.baseurl }}/docs/questions.html
-[standard]: https://getbootstrap.com/docs/4.0/components/forms/#form-groups
-[horizontal form]: https://getbootstrap.com/docs/4.0/components/forms/#horizontal-form
+[standard]: https://getbootstrap.com/docs/5.0/forms/layout/#utilities/
+[horizontal form]: https://getbootstrap.com/docs/5.0/forms/layout/#horizontal-form
 [`exitpage`]: {{ site.baseurl }}/docs/config.html#exitpage
 [special pages]: {{ site.baseurl }}/docs/questions.html#special buttons
 [`command()`]: {{ site.baseurl }}/docs/functions.html#command
@@ -2639,7 +2639,7 @@ This will cause the web application to run the JavaScript for the
 [`DALazyTemplate`]: {{ site.baseurl }}/docs/objects.html#DALazyTemplate
 [provide CSS]: #css
 [adjust the CSS]: {{ site.baseurl }}/docs/config.html#bootstrap theme
-[Bootstrap Navbar]: https://getbootstrap.com/docs/4.0/components/navbar/#supported-content
+[Bootstrap Navbar]: https://getbootstrap.com/docs/5.0/components/navbar/#supported-content
 [`__all__`]: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package
 [translation files]: #translations
 [`language`]: {{ site.baseurl }}/docs/config.html#language

--- a/_docs/interviews.md
+++ b/_docs/interviews.md
@@ -647,7 +647,7 @@ than [using an iframe] because you need to reconcile the [CSS] and
 The [Drupal module] and [WordPress plugin] both support embedding
 interviews into `<div>` elements.
 
-**docassemble** depends on the [CSS] classes of [Bootstrap 4] being
+**docassemble** depends on the [CSS] classes of [Bootstrap 5] being
 defined.  Your site's [CSS] should be loaded after the [CSS] needed by
 **docassemble**, so that it overrides the **docassemble** [CSS] rules.
 (The [Drupal module] and [WordPress plugin] are configured to do
@@ -1127,7 +1127,7 @@ containing `# use jinja` was encountered.
 [jQuery]: http://jquery.com/
 [jQuery Validation Plugin]: http://jqueryvalidation.org/maxlength-method
 [using an iframe]: #iframe
-[Bootstrap 4]: http://getbootstrap.com/
+[Bootstrap 5]: http://getbootstrap.com/
 [Bootstrap]: http://getbootstrap.com/
 [Ajax]: https://en.wikipedia.org/wiki/Ajax_(programming)
 [favicon]: https://en.wikipedia.org/wiki/Favicon

--- a/_docs/objects.md
+++ b/_docs/objects.md
@@ -7150,7 +7150,7 @@ the `_uid` of the table rather than the `id`.
 [actions]: {{ site.baseurl }}/docs/background.html#url_action
 [screen part]: {{ site.baseurl }}/docs/questions.html#screen parts
 [`breadcrumb` modifier]: {{ site.baseurl }}/docs/modifiers.html#breadcrumb
-[Bootstrap format]: https://getbootstrap.com/docs/4.0/components/breadcrumb/
+[Bootstrap format]: https://getbootstrap.com/docs/5.0/components/breadcrumb/
 [`review`]: {{ site.baseurl }}/docs/fields.html#review
 [`png resolution`]: {{ site.baseurl }}/docs/config.html#png resolution
 [`png screen resolution`]: {{ site.baseurl }}/docs/config.html#png screen resolution

--- a/_docs/questions.md
+++ b/_docs/questions.md
@@ -621,4 +621,4 @@ For more information about each method, see its documentation.
 [JSON]: https://en.wikipedia.org/wiki/JSON
 [provide CSS]: {{ site.baseurl }}/docs/initial.html#css
 [adjust the CSS]: {{ site.baseurl }}/docs/config.html#bootstrap theme
-[Bootstrap Navbar]: https://getbootstrap.com/docs/4.0/components/navbar/#supported-content
+[Bootstrap Navbar]: https://getbootstrap.com/docs/5.0/components/navbar/#supported-content

--- a/_docs/recipes.md
+++ b/_docs/recipes.md
@@ -2455,7 +2455,7 @@ the [`ics`] package.
 [`pdf template file`]: {{ site.baseurl }}/docs/documents.html#pdf template file
 [YAML]: https://en.wikipedia.org/wiki/YAML
 [`signature-diversion.yml`]: https://github.com/jhpyle/docassemble/blob/master/docassemble_demo/docassemble/demo/data/questions/signature-diversion.yml
-[collapse feature]: https://getbootstrap.com/docs/4.0/components/collapse/
+[collapse feature]: https://getbootstrap.com/docs/5.0/components/collapse/
 [Bootstrap]: https://getbootstrap.com/
 [`disable others`]: {{ site.baseurl }}/docs/fields.html#disable others
 [`object` datatype]: {{ site.baseurl }}/docs/fields.html#object


### PR DESCRIPTION
Things were [updated to Bootstrap 5.0](https://github.com/jhpyle/docassemble/commit/b8eb2212f2bd7a5dbe6f66bc03253c39fd6dc699) a while back, so I updated the relevant links in the documentation to point to bootstrap 5.