### PR TITLE
Add invalidate to special review field commands

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -4165,7 +4165,7 @@ class Question:
                             field_list = field[key]
                         field_info['data'] = []
                         for the_saveas in field_list:
-                            if isinstance(the_saveas, dict) and len(the_saveas) == 1 and ('undefine' in the_saveas or 'recompute' in the_saveas or 'set' in the_saveas or 'follow up' in the_saveas):
+                            if isinstance(the_saveas, dict) and len(the_saveas) == 1 and (next(iter(the_saveas)) in ('undefine', 'recompute', 'set', 'follow up', 'invalidate')):
                                 if 'set' in the_saveas:
                                     if not isinstance(the_saveas['set'], list):
                                         raise DAError("The set statement must refer to a list." + self.idebug(data))

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -2319,11 +2319,11 @@ class DADict(DAObject):
         """Invalidate items."""
         for item in pargs:
             if item in self.elements.keys():
-                invalidate(self.instanceName + '[' + repr(item) + ']')
+                invalidate(self.item_name(item))
     def getitem_fresh(self, item):
         """Compute a fresh value of the given item and return it."""
         if item in self.elements:
-            docassemble.base.functions.reconsider(self.instanceName + '[' + repr(item) + ']')
+            docassemble.base.functions.reconsider(self.item_name(item))
         return self[item]
     def all_false(self, *pargs, **kwargs):
         """Returns True if the values of all keys are false.  If one or more


### PR DESCRIPTION
Invalidate is referenced in a more inner for loop, but not in an outer for loop.

Also used an existing function when generating the name of a dictionary value