### PR TITLE
Let the `address_autocomplete` attribute be false

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -3993,7 +3993,7 @@ class Question:
                                     field_info['selections']['exclude'].append(compile(x, '<expression>', 'eval'))
                                     self.find_fields_in(x)
                     elif key == 'address autocomplete':
-                        field_info['address_autocomplete'] = True
+                        field_info['address_autocomplete'] = bool(field[key])
                     elif key == 'label above field':
                         field_info['label_above_field'] = True
                     elif key == 'floating label':


### PR DESCRIPTION
If you set `address autocomplete` to False in an address.address field, the value saved by the server is still True.

Our reason for setting the `address autocomplete` to False is so our `address_fields()` (https://github.com/SuffolkLITLab/docassemble-AssemblyLine/blob/f7d1144c1ff4a0535bfd143b5c320a38c28cb493/docassemble/AssemblyLine/al_general.py#L72) is can check if the server has the correct google maps api key; if it does, then we set it to true, if something is missing, then we set it to false, to avoid a javascript error on the page.