### PR TITLE
Add Flask_Mail as a dependency of docassemble.base

### DIFF
--- a/docassemble_base/setup.py
+++ b/docassemble_base/setup.py
@@ -89,6 +89,7 @@ install_requires = [
     "docxcompose==1.3.4",
     "docxtpl==0.16.3",
     "et-xmlfile==1.1.0",
+    "Flask-Mail==0.9.1",
     "future==0.18.2",
     "geographiclib==1.52",
     "geopy==2.2.0",


### PR DESCRIPTION
It's used in `util.py:send_email`. With this addition, you can install `docassemble.base` without installing `docassemble.webapp`, and call (most) of the functions. Doesn't entirely work, but all of the dependencies are present now.