### PR TITLE
Don't call for pypi status if turned off on server

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -19734,8 +19734,8 @@ def playground_packages():
         return redirect(url_for('playground_packages', project=current_project))
     if not is_new:
         pkgname = 'docassemble.' + the_file
-        pypi_info = pypi_status(pkgname)
         if can_publish_to_pypi:
+            pypi_info = pypi_status(pkgname)
             if pypi_info['error']:
                 pypi_message = word("Unable to determine if the package is published on PyPI.")
             else:
@@ -19761,7 +19761,7 @@ def playground_packages():
                     old_filename = os.path.join(directory_for(area['playgroundpackages'], current_project), 'docassemble.' + form.original_file_name.data)
                     if os.path.isfile(old_filename):
                         os.remove(old_filename)
-                if form.pypi.data and pypi_version is not None:
+                if can_publish_to_pypi and form.pypi.data and pypi_version is not None:
                     if not new_info['version']:
                         new_info['version'] = pypi_version
                     while 'releases' in pypi_info['info'] and new_info['version'] in pypi_info['info']['releases'].keys():


### PR DESCRIPTION
If we don't show any pypi information on the package screen, don't query pypi for it.

I did some testing of why opening the package screen takes a while on certain servers. From some of my tests, calling pypi can take ~1/3rd of the load time (from [py-spy](https://github.com/benfred/py-spy) samples), so this should give a small speed boost to those with pypi turned off on their servers.

`can_publish_to_pypi` is calculated for both GET and POST, and it's only dependent on configs (the POST vars assume it was on when GET returned the form), so adding it to the `if` should change semantics. Tested on a small local server, and worked as expected (the pypi status of a package was shown correctly on the packages screen when turned on).