### PR TITLE
Improve performance of bates numbering

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -4343,7 +4343,7 @@ class DAFile(DAObject):
             raise DAError("bates_number: area must be one of TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, or BOTTOM_LEFT")
         if filename is None:
             filename = 'file.pdf'
-        args = [os.path.join(server.daconfig['modules'], 'bin', 'python'), '-m', 'docassemble.base.bates', '--prefix', str(prefix), '--digits', str(digits), '--start', str(start), '--area', area]
+        args = [os.path.join(server.daconfig['modules'], 'bin', 'python'), '-m', 'docassemble.base.bates', '--prefix', '"' + str(prefix) + '"', '--digits', str(digits), '--start', str(start), '--area', area]
         for doc in docs:
             if isinstance(doc, str):
                 args.append(doc)

--- a/docassemble_base/setup.py
+++ b/docassemble_base/setup.py
@@ -146,6 +146,7 @@ install_requires = [
     "pdfminer.six==20220319",
     "phonenumbers==8.12.46",
     "Pillow==9.3.0",
+    "pikepdf==6.2.4",
     "pkginfo==1.8.2",
     "pluggy==1.0.0",
     "ply==3.11",


### PR DESCRIPTION
Was running into some performance of bates numbering on large PDFs (~700 pages, taking 2 or 3 minutes and timing out consistently). PyPdf's `mergePage()` function, used in `marisol.py`, seemed to take up much of the compute. I'm not sure why.

I changed it to use `pikepdf` instead, which has a similar `add_overlay()` function, that doesn't copy each page from the PDF individually. Since marisol hasn't been updated since 2017, it's likely safe to fork from it. If there are updates from upstream, I'd be happy to merge those personally.

Test results:

On 17 various PDFs (gathered from my local machine, so they have personal info,
happy to DM the files if wanted), with a total of 1659 pages,
* before this PR, took 226.35 seconds
* after this PR, took 13.13 seconds
* no visible difference on the output PDFs before or after. This is expected, as the way of generating the numbering overlay (with reportlab) is unchanged.

Also tested on the server, no longer times out.