### PR TITLE
sklearn is deprecated for scikit-learn

### DIFF
--- a/docassemble_webapp/setup.py
+++ b/docassemble_webapp/setup.py
@@ -223,7 +223,6 @@ install_requires = [
     "sendgrid==6.9.7",
     "simplekv==0.14.1",
     "six==1.16.0",
-    "sklearn==0.0",
     "sniffio==1.2.0",
     "SocksiPy-branch==1.1",
     "sortedcontainers==2.4.0",


### PR DESCRIPTION
sklearn is intentionally breaking pip builds for 5 minutes of every hour at the moment, slowly increasing until it's broken, I've run into this a few times when installing docassemble packages. See this github repo for the full details: https://github.com/scikit-learn/sklearn-pypi-package