### PR TITLE
Lets you use font-awesome prefixes everywhere

### DIFF
--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1269,16 +1269,7 @@ def rtf_two_col(match):
     return table_text + '[MANUALSKIP]'
 
 
-def emoji_html(text, status=None, question=None, images=None):
-    # logmessage("Got to emoji_html")
-    if status is not None and question is None:
-        question = status.question
-    if images is None:
-        images = question.interview.images
-    if text in images:
-        if status is not None and images[text].attribution is not None:
-            status.attributions.add(images[text].attribution)
-        return image_url(images[text].get_reference(), word('icon'), '1em', emoji=True, question=question)
+def get_icon_html(text):
     icons_setting = docassemble.base.functions.get_config('default icons', None)
     if icons_setting == 'font awesome':
         m = re.search(r'^(fa[a-z])-fa-(.*)', text)
@@ -1290,6 +1281,22 @@ def emoji_html(text, status=None, question=None, images=None):
         return '<i class="' + the_prefix + ' fa-' + str(text) + '"></i>'
     if icons_setting == 'material icons':
         return '<i class="da-material-icons">' + str(text) + '</i>'
+    return None
+
+
+def emoji_html(text, status=None, question=None, images=None):
+    # logmessage("Got to emoji_html")
+    if status is not None and question is None:
+        question = status.question
+    if images is None:
+        images = question.interview.images
+    if text in images:
+        if status is not None and images[text].attribution is not None:
+            status.attributions.add(images[text].attribution)
+        return image_url(images[text].get_reference(), word('icon'), '1em', emoji=True, question=question)
+    icon_html = get_icon_html(text)
+    if icon_html:
+        return icon_html
     return ":" + str(text) + ":"
 
 

--- a/docassemble_base/docassemble/base/standardformatter.py
+++ b/docassemble_base/docassemble/base/standardformatter.py
@@ -10,7 +10,7 @@ from html.parser import HTMLParser
 from docassemble.base.functions import word, get_currency_symbol, comma_and_list, server, custom_types, get_locale
 from docassemble.base.util import format_date, format_datetime, format_time
 # from docassemble.base.generate_key import random_string
-from docassemble.base.filter import markdown_to_html, get_audio_urls, get_video_urls, audio_control, video_control, noquote, to_text, my_escape, process_target
+from docassemble.base.filter import markdown_to_html, get_audio_urls, get_video_urls, audio_control, video_control, noquote, to_text, my_escape, process_target, get_icon_html
 from docassemble.base.parse import Question
 from docassemble.base.logger import logmessage
 from docassemble.base.config import daconfig
@@ -130,11 +130,8 @@ def icon_html(status, name, width_value=1.0, width_units='em'):
         is_decoration = True
         the_image = status.question.interview.images.get(name, None)
         if the_image is None:
-            if daconfig.get('default icons', None) == 'font awesome':
-                return '<i class="' + daconfig.get('font awesome prefix', 'fas') + ' fa-' + str(name) + '"></i>'
-            if daconfig.get('default icons', None) == 'material icons':
-                return '<i class="da-material-icons">' + str(name) + '</i>'
-            return ''
+            icon = get_icon_html(str(name))
+            return icon if icon else ""
         if the_image.attribution is not None:
             status.attributions.add(the_image.attribution)
         url = server.url_finder(str(the_image.package) + ':' + str(the_image.filename))
@@ -693,10 +690,10 @@ def as_html(status, debug, root, validation_rules, field_error, the_progress_bar
                         if the_image.attribution is not None:
                             status.attributions.add(the_image.attribution)
                         decorations.append('<img alt="" class="daiconfloat" style="' + sizing + '" src="' + url + '"/>')
-                elif daconfig.get('default icons', None) == 'font awesome':
-                    decorations.append('<span style="font-size: ' + str(DECORATION_SIZE) + str(DECORATION_UNITS) + '" class="dadecoration"><i class="' + daconfig.get('font awesome prefix', 'fas') + ' fa-' + str(decoration['image']) + '"></i></span>')
-                elif daconfig.get('default icons', None) == 'material icons':
-                    decorations.append('<span style="font-size: ' + str(DECORATION_SIZE) + str(DECORATION_UNITS) + '" class="dadecoration"><i class="da-material-icons">' + str(decoration['image']) + '</i></span>')
+                else:
+                  icon = get_icon_html(str(decoration["image"]))
+                  if icon:
+                      decorations.append('<span style="font-size: ' + str(DECORATION_SIZE) + str(DECORATION_UNITS) + '" class="dadecoration">' + icon + '</span>')
     if len(decorations) > 0:
         decoration_text = decorations[0]
     else:


### PR DESCRIPTION
Including in `buttons` and `choices` image attributes, not just inline. The [icon documentation](https://docassemble.org/docs/config.html#default%20icons) suggests that this should be the case every where, and this PR brings everything up to line with that expectation.

Necessary to show font-awesome icons from different styles, like "brand".

Here's a test interview to show the new functionality, and that it doesn't break existing font awesome functionality.
```yml
mandatory: True
question: |
  Choose a Design Library
decoration:
  pencil
subquestion: |
  :fab-fa-bootstrap:
  
  :pencil:
buttons:
  - Bootstrap: bootstrap_stuff
    image: fab-fa-bootstrap
  - Pencil and Paper: pencil_and_paper
    image: pencil
```

On 1.4.30:

![Screenshot of a question screen. The bootstrap logo is not visible, only a flashing exclamation point](https://user-images.githubusercontent.com/6252212/215891247-19550610-2f80-492c-a223-b13c15c8cfa6.png)


With this patch:

![Screenshot of a question screen. The bootstrap logo is visible on a button](https://user-images.githubusercontent.com/6252212/215891260-20711436-00f5-4950-a64e-0b2eb573aed6.png)

Tested with decoration as well to make sure it works.
