### PR TITLE
Be able to read radio buttons properly

### DIFF
--- a/docassemble_base/docassemble/base/pdftk.py
+++ b/docassemble_base/docassemble/base/pdftk.py
@@ -60,7 +60,7 @@ def fieldsorter(x):
     return (x[2], y_coord, x_coord)
 
 
-def recursively_add_fields(fields, id_to_page, outfields, prefix=''):
+def recursively_add_fields(fields, id_to_page, outfields, prefix='', parent_ft=None):
     if isinstance(fields, PDFObjRef):
         fields = resolve1(fields)
     for i in fields:
@@ -69,6 +69,10 @@ def recursively_add_fields(fields, id_to_page, outfields, prefix=''):
             field = resolve1(field)
         try:
             name, value, rect, page, field_type = field.get('T'), field.get('V'), field.get('Rect'), field.get('P'), field.get('FT')
+            if field_type is None:
+                widget_type = str(field.get("Type"))
+                if widget_type == "/'Annot'" or widget_type == "/Annot":
+                    field_type = parent_ft
         except:
             logmessage("Skipping field " + repr(field))
             continue
@@ -131,12 +135,12 @@ def recursively_add_fields(fields, id_to_page, outfields, prefix=''):
         kids = field.get('Kids')
         if kids:
             if name is None:
-                recursively_add_fields(kids, id_to_page, outfields, prefix=prefix)
+                recursively_add_fields(kids, id_to_page, outfields, prefix=prefix, parent_ft=field_type)
             else:
                 if prefix == '':
-                    recursively_add_fields(kids, id_to_page, outfields, prefix=name)
+                    recursively_add_fields(kids, id_to_page, outfields, prefix=name, parent_ft=field_type)
                 else:
-                    recursively_add_fields(kids, id_to_page, outfields, prefix=prefix + '.' + name)
+                    recursively_add_fields(kids, id_to_page, outfields, prefix=prefix + '.' + name, parent_ft=field_type)
         else:
             if prefix != '' and name is not None:
                 outfields.append((prefix + '.' + name, default, pageno, rect, field_type, export_value))


### PR DESCRIPTION
In PDFs, Radio buttons are terminal fields that can still have children ("Kids", in the PDF object), which are annotations that display the value of the radio button, checking or circling the selected button choice. 

Radio buttons from Adobe are formatted differently than other programs; the `Kids` annotations don't have the `Ft` (field type) (and aren't required to by the PDF spec). So when `read_fields` recurses down into `Kids`, if it can't find a field type and the Kid is actually marked as an annotation, we should remember the parent's field type and use it instead.

An example PDF, and the results of `pdftk.read_fields` before this change:

```python
[('Group1', 'something', 1, [162.937, 631.267, 180.937, 649.267], None, None),
 ('Group1', 'something', 1, [164.241, 601.938, 182.241, 619.938], None, None),
 ('Group1', 'something', 1, [163.589, 571.958, 181.589, 589.958], None, None)]
```

and after:

```python
[('Group1', 'No', 1, [162.937, 631.267, 180.937, 649.267], /'Btn', 'Choice1'),
 ('Group1', 'No', 1, [164.241, 601.938, 182.241, 619.938], /'Btn', 'Choice2'),
 ('Group1', 'No', 1, [163.589, 571.958, 181.589, 589.958], /'Btn', 'Choice3')]
```

There is one more issue with radio buttons and setting values that I have in progress and will make a PR for soon.

Some long standing discussion about this issue is in https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/75.