### PR TITLE
Write radio buttons and checkboxes for more viewers

### DIFF
--- a/docassemble_base/docassemble/base/pdftk.py
+++ b/docassemble_base/docassemble/base/pdftk.py
@@ -269,19 +269,22 @@ def fill_template(template, data_strings=None, data_names=None, hidden=None, rea
                         if hasattr(annot, "A"):
                             continue
                         the_name = pikepdf.Name('/' + value)
-                        annot.AS = the_name
                         annot.V = the_name
                         annot.DV = the_name
                         # Could be radio button: if it is, set the appearance stream of the
                         # correct child annot
                         if (annot_kid is not None and hasattr(annot_kid, "AP")
                                 and hasattr(annot_kid.AP, "N")):
+                            annot.AS = the_name
                             if the_name in annot_kid.AP.N.keys():
                                 annot_kid.AS = the_name
                             else:
                                 for off in ["/Off", "/off"]:
                                     if off in annot_kid.AP.N.keys():
                                         annot_kid.AS = off
+                        elif (hasattr(annot, "AP") and hasattr(annot.AP, "N")):
+                            if the_name in annot.AP.N.keys():
+                                annot.AS = the_name
                     elif field_type == "/Ch":
                         opt_list = [str(item) for item in annot.Opt]
                         if value not in opt_list:

--- a/docassemble_base/docassemble/base/pdftk.py
+++ b/docassemble_base/docassemble/base/pdftk.py
@@ -168,22 +168,32 @@ def fill_template(template, data_strings=None, data_names=None, hidden=None, rea
     for field, default, pageno, rect, field_type, export_value in the_fields:  # pylint: disable=unused-variable
         field_type = re.sub(r'[^/A-Za-z]', '', str(field_type))
         if field_type in ('/Btn', "/'Btn'"):
-            export_values[field] = export_value or default_export_value or 'Yes'
+            if field in export_values.keys():
+                export_values[field].append(export_value or default_export_value or 'Yes')
+            else:
+                export_values[field] = [export_value or default_export_value or 'Yes']
     if len(export_values) > 0:
         new_data_strings = []
         for key, val in data_strings:
-            if key in export_values:
-                if str(val) in ('Yes', 'yes', 'True', 'true', 'On', 'on', export_values[key]):
-                    val = export_values[key]
-                else:
-                    if export_values[key] == 'On':
+            if key in export_values and len(export_values[key]) > 0:
+                if len(export_values[key]) > 1:
+                    # Implies a radio button, so val should stay the same. Just turn things off
+                    # if it doesn't match any value
+                    if val not in export_values[key]:
                         val = 'Off'
-                    elif export_values[key] == 'on':
-                        val = 'off'
-                    elif export_values[key] == 'yes':
-                        val = 'no'
+                else:
+                    export_val = export_values[key][0]
+                    if str(val) in ('Yes', 'yes', 'True', 'true', 'On', 'on', export_val):
+                        val = export_val
                     else:
-                        val = 'No'
+                        if export_val == 'On':
+                            val = 'Off'
+                        elif export_val == 'on':
+                            val = 'off'
+                        elif export_val == 'yes':
+                            val = 'no'
+                        else:
+                            val = 'No'
             new_data_strings.append((key, val))
         data_strings = new_data_strings
     data_dict = {}
@@ -242,7 +252,9 @@ def fill_template(template, data_strings=None, data_names=None, hidden=None, rea
             for the_annot in page.Annots:
                 for field, value in data_dict.items():
                     annot = the_annot
-                    while not hasattr(annot, "FT") and hasattr(annot, 'Parent'):
+                    annot_kid = None
+                    while not (hasattr(annot, "FT") and hasattr(annot, "T")) and hasattr(annot, 'Parent'):
+                        annot_kid = annot
                         annot = annot.Parent
                     if not (hasattr(annot, "T") and hasattr(annot, "FT")):
                         continue
@@ -260,6 +272,16 @@ def fill_template(template, data_strings=None, data_names=None, hidden=None, rea
                         annot.AS = the_name
                         annot.V = the_name
                         annot.DV = the_name
+                        # Could be radio button: if it is, set the appearance stream of the
+                        # correct child annot
+                        if (annot_kid is not None and hasattr(annot_kid, "AP")
+                                and hasattr(annot_kid.AP, "N")):
+                            if the_name in annot_kid.AP.N.keys():
+                                annot_kid.AS = the_name
+                            else:
+                                for off in ["/Off", "/off"]:
+                                    if off in annot_kid.AP.N.keys():
+                                        annot_kid.AS = off
                     elif field_type == "/Ch":
                         opt_list = [str(item) for item in annot.Opt]
                         if value not in opt_list:


### PR DESCRIPTION
Currently docassemble can set the value of a radio button correctly. However,
in some PDF viewers (I tested in Ubuntu's Evince document viewer), the selected
radio button doesn't appear properly. This is because while docassemble
sets `/V` on the radio button group annotation, it doesn't set the `/AS`
(appearance stream) of the child annotation, which some viewers use to
actually which radio button is selected.

This PR makes the following changes to fix the issue:

* allows `export_values` to handle multiple values on the same field.
  For radio buttons, means that if a template already has a radio button
  selected, it won't override the given value in `data_strings`.
* Children of terminal fields don't have to have either FT or T, so
  look until a parent does and don't stop if the kid has FT, but not T
* keep track of when we have a child annotation of a `/Btn`, and make
  sure to set the appearance stream of that child to be the proper
  selected value

The second commit deals with a similar issue between PDF viewers, 
but for checkboxes. On certain checkboxes, there is only a `Yes` / `On` value
in the `N` dict, and not an `Off` dict. This means that if a
checkbox is explictly set to "Off", then some PDF viewers will
still show the box as checked, since setting `/AS` to a value
not in one of the Appearence Stream dictionaries (`/N` or `/D`)
is undefined in the spec.

This commit makes sure that the value AS is set to
is present in in `AP.N`, and if it's not present, it`s not set.

Tested with several PDFs made by different means, mostly by directly calling the `pdftk.fill_template`,
function, but also did an end-to-end test in the playground. Additional examples to test with are
appreciated.
* tested checking the "Medicaid" checkbox on this PDF, setting it to "Yes", and "Off".
    * [affidavitofindigency.pdf](https://github.com/jhpyle/docassemble/files/10701802/affidavitofindigency.pdf)
* tested checking the radio buttons in the following two PDFs.
    * [radios.pdf](https://github.com/jhpyle/docassemble/files/10701789/radios.pdf) (Group: 'abc', options 'option a', and 'option b'. This one I wasn't able to view properly in all viewers, but it did work in the majority of them).
    * [ExampleAdobePDF.pdf](https://github.com/jhpyle/docassemble/files/10701797/ExampleAdobePDF.pdf) (Group 'Group1', options "Choice1", "Choice2", "Choice3")

This PR is related to, but not dependent on, https://github.com/jhpyle/docassemble/pull/619.
Some long standing discussion about this issue is in https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/75.
