### PR TITLE
Check for `da:install_status:...` when restarting

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -28246,6 +28246,10 @@ def api_restart_status():
     the_key = 'da:restart_status:' + str(code)
     task_data = r.get(the_key)
     if task_data is None:
+        # Try again with install_status
+        the_key = 'da:install_status:' + str(code)
+        task_data = r.get(the_key)
+    if task_data is None:
         return jsonify(status='unknown')
     task_info = json.loads(task_data.decode())
     if START_TIME <= task_info['server_start_time']:


### PR DESCRIPTION
When the server restarts for some reason, it saves the background task id under `da:restart_status:...`, or as `da:install_status:...` if a package is being installed to the server.

When someone calls `/api/restart_status`, DA will check if the given task id key is either `restart_status` or `install_status`, instead of just checking `restart_status`.