### PR TITLE
Document the DA_ADMIN_EMAIL and PASSWORD env vars

### DIFF
--- a/_docs/docker.md
+++ b/_docs/docker.md
@@ -847,6 +847,13 @@ over any values you specify in `env.list`.  If you are using
 edit these configuration files in the cloud and then stop and start
 your container for the new configuration to take effect.
 
+* <a name="DA_ADMIN_EMAIL"></a>DA_ADMIN_EMAIL: This is used to set
+  the initial admin user's email. If not set it defaults to
+  "admin@admin.com".
+* <a name="DA_ADMIN_PASSWORD"></a>DA_ADMIN_PASSWORD: This is used to
+  set the initial admin user's password. If not set it defaults to
+  "password". This should be set to avoid leaving the default
+  admin password exposed.
 * <a name="DAWEBSERVER"></a>`DAWEBSERVER`: This can be set either to
   `nginx` (the default) or `apache`.  See the [`web server`]
   configuration directive.


### PR DESCRIPTION
Shows users that the `DA_ADMIN_EMAIL` and `DA_ADMIN_PASSWORD` configuration env vars exist, which lets people change the default admin email and password. Doing so lets sysadmins avoid someone else finding their newly created server before they do and logging in.