### PR TITLE
Return the 400 speakfile errors like other errors

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -12830,10 +12830,10 @@ def speak_file():
     audio_file = None
     filename = request.args.get('i', None)
     if filename is None:
-        abort(400)
+        return ('You must pass the filename (i) to read it out loud', 400)
     session_info = get_session(filename)
     if session_info is None:
-        abort(400)
+        return ("You must include a session to read a screen out loud", 400)
     key = session_info['uid']
     # encrypted = session_info['encrypted']
     question = request.args.get('question', None)


### PR DESCRIPTION
Instead of calling `abort`, return the 400 errors as the other errors are returned. Doesn't show the full docassemble screen as normal, but it does prevent error logs from appearing, and matches the other ways of returning errors.