### PR TITLE
description-file -> description_file

### DIFF
--- a/docassemble_webapp/docassemble/webapp/files.py
+++ b/docassemble_webapp/docassemble/webapp/files.py
@@ -595,7 +595,7 @@ include README.md
 """
     setupcfg = """\
 [metadata]
-description-file = README.md
+description_file = README.md
 """
     setuppy = """\
 import os

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -16881,7 +16881,7 @@ include README.md
 """
         setupcfg = """\
 [metadata]
-description-file = README
+description_file = README
 """
         setuppy = """\
 import os


### PR DESCRIPTION
Setuptools has deprecated `description-file`, and given a specific date after which it will start breaking installing certain packages (Sept 26 2023).

This patch changes docassemble's output of packages from `description-file` to the suggested replacement, `description_file`.

The full pip error:

******************************************************************************** 
Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead.

By 2023-Sep-26, you need to update your project and remove deprecated calls or your builds will no longer be supported.

See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
********************************************************************************