### PR TITLE
Don't always pass email as session uid

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -5778,7 +5778,7 @@ def restart_session():
         secret = request.cookies.get('secret', None)
     if secret is not None:
         secret = str(secret)
-    docassemble.base.functions.this_thread.current_info = current_info(yaml=yaml_filename, req=request, interface='vars', device_id=request.cookies.get('ds', None), session_uid=current_user.email)
+    docassemble.base.functions.this_thread.current_info = current_info(yaml=yaml_filename, req=request, interface='vars', device_id=request.cookies.get('ds', None), session_uid=current_user.email if hasattr(current_user, 'email') else None)
     try:
         steps, user_dict, is_encrypted = fetch_user_dict(session_id, yaml_filename, secret=secret)  # pylint: disable=unused-variable
     except:


### PR DESCRIPTION
In some interviews, we have the following restart link (in the footer, but the location on the screen shouldn't matter):

```mako
${ url_of('restart') } )
```
If a user is not logged in, DA crashes. The issue is that the `restart_session` endpoint expects an email to be present.

This fixes the issue by passing `None` as the email, which happens in other places for not logged in users as well.