### PR TITLE
Update reportlab to 3.6.13 for security patch

### DIFF
--- a/docassemble_base/setup.py
+++ b/docassemble_base/setup.py
@@ -185,7 +185,7 @@ install_requires = [
     "qrcode==7.4.1",
     "readme-renderer==37.3",
     "regex==2022.10.31",
-    "reportlab==3.6.12",
+    "reportlab==3.6.13",
     "repoze.lru==0.7",
     "requests==2.28.2",
     "requests-oauthlib==1.3.1",

--- a/docassemble_webapp/setup.py
+++ b/docassemble_webapp/setup.py
@@ -209,7 +209,7 @@ install_requires = [
     "readme-renderer==37.3",
     "redis==4.4.4",
     "regex==2022.10.31",
-    "reportlab==3.6.12",
+    "reportlab==3.6.13",
     "repoze.lru==0.7",
     "requests==2.28.2",
     "requests-oauthlib==1.3.1",


### PR DESCRIPTION
From the reportlab mailing list:

>    These fix a potential security vulnerability in the parsing of colours.
    Previously, Iif someone had coded an application allowing user-input
    expressions to be passed to our toColor constructor function, there was a
    way to execute inappropriate code.  If you are doing this, please upgrade
    to the newest version.
    
>    If, however, there are no external inputs and colours are set by you in code
    (or validated to be simple and reasonable expressions), there is no vulnerability.
    
I don't see any uses of `toColor` in docassemble, but I'm not sure if there are internal uses of `toColor` in reportlab that docassemble still uses, or if docassemble users use `toColor` in their own applications. So, better to be safe, but I wouldn't prioritize it or call it urgent.