### PR TITLE
Allow `_use_jinja2=True` in include_docx_template

### DIFF
--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -128,7 +128,7 @@ def fix_subdoc(masterdoc, subdoc_info):
 
 def include_docx_template(template_file, **kwargs):
     """Include the contents of one docx file inside another docx file."""
-    use_jinja = kwargs.get('_use_jinja2', True)
+    use_jinja = kwargs.pop('_use_jinja2', True)
     if this_thread.evaluation_context is None:
         return 'ERROR: not in a docx file'
     if template_file.__class__.__name__ in ('DAFile', 'DAFileList', 'DAFileCollection', 'DALocalFile', 'DAStaticFile'):
@@ -144,11 +144,7 @@ def include_docx_template(template_file, **kwargs):
         del kwargs['_inline']
     else:
         single_paragraph = False
-    if 'change_numbering' in kwargs:
-        change_numbering = bool(kwargs['change_numbering'])
-        del kwargs['change_numbering']
-    else:
-        change_numbering = True
+    change_numbering = bool(kwargs.pop('change_numbering', True))
 
     # We need to keep a copy of the subdocs so we can fix up the master template in the end (in parse.py)
     # Given we're half way through processing the template, we can't fix the master template here


### PR DESCRIPTION
Ideally, `_use_jinja2=True` should act the same as the default call to `include_docx_template`, since True is the default. However, since `include_docx_template` doesn't remove the param from `kwargs`, the function will fail later when it tries to encode the value of the param.

The error looks like:

```
"/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/file_docx.py", line 168, in include_docx_template   
    the_repr = '_codecs.decode(_array.array("b", "' + re.sub(r'\n', '', codecs.encode(bytearray(val, encoding='utf-8'), 'base64').decode()) + '".encode()), "base64").decode()' 
TypeError: encoding without a string argument`.
```

Easy work around (just don't pass `_use_jinja2` if you use True), but also a pretty easy fix that I've had sitting around for a while.

This commit fixes the issue by using `pop`, and also simplifies the `change_numbering` param by doing the same thing.