### PR TITLE
Allow "True" and "False" as radio button choices

### DIFF
--- a/docassemble_base/docassemble/base/pdftk.py
+++ b/docassemble_base/docassemble/base/pdftk.py
@@ -181,8 +181,13 @@ def fill_template(template, data_strings=None, data_names=None, hidden=None, rea
         for key, val in data_strings:
             if key in export_values and len(export_values[key]) > 0:
                 if len(export_values[key]) > 1:
-                    # Implies a radio button, so val should stay the same. Just turn things off
-                    # if it doesn't match any value
+                    # Implies a radio button, so val should stay the same. Check for yes vs True, since
+                    # parse.py turns "true" into "yes".
+                    # Just turn things off if it doesn't match any value
+                    if 'True' in export_values[key] and (val == "Yes" or val == "yes"):
+                        val = 'True'
+                    if 'False' in export_values[key] and (val == "No" or val == "no"):
+                        val = 'False'
                     if val not in export_values[key]:
                         val = 'Off'
                 else:


### PR DESCRIPTION
`parse.py` turns all "True" and "False"-like values into "Yes" and "No", presumably for text conversion and how push buttons work. However, this breaks radio buttons, which need exact string matching to properly set their values.

This PR turns the data_string values back into `"True"` and `"False"` if a particular field is a radio button, which we don't know before then.

Tested with an example from the slack; this interview:

```yml
question: |
 Select one ?
field: is_check
buttons:
  - YES: True 
  - NO: False
---
mandatory: true
question: Check Done.
subquestion: |
 ${ is_check }
attachment:
  - name: check
    filename: check
    pdf template file: check.pdf
    fields:
      - "radio-button": ${ is_check }
```
filling in this PDF:

[check.pdf](https://github.com/jhpyle/docassemble/files/11454611/check.pdf)


