### PR TITLE
JSON-ize things returned from a background action

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -6237,7 +6237,7 @@ def checkin():
                         result = docassemble.webapp.worker.workerapp.AsyncResult(id=worker_id)
                         if result.ready():
                             if isinstance(result.result, ReturnValue):
-                                commands.append({'value': result.result.value, 'extra': result.result.extra})
+                                commands.append({'value': docassemble.base.functions.safe_json(result.result.value), 'extra': result.result.extra})
                         else:
                             r.rpush(worker_key, worker_id)
                     except Exception as errstr:


### PR DESCRIPTION
This continues on work in https://github.com/jhpyle/docassemble/commit/8d1b84777ce626170e44d83e09de523bbfca5e50#diff-4c8bf136c393acf44c18098d2b935b3a005636e57574530acffdf552432360faR5751 (1.4.0). That commit ran avoided running the results from a refresh from a background action, but only if `do_action` was set. There is also a section that get the final values from finished workers directly that hadn't been calling `safe_json` on the results, causing errors like: 

```
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/server.py", line 6250, in checkin
    return jsonify_with_cache(success=True, chat_status=chatstatus, num_peers=num_peers, help_available=help_available, phone=call_forwarding_message, observerControl=observer_control, commands=commands, checkin_code=checkin_code)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/server.py", line 5970, in jsonify_with_cache
    response = jsonify(*pargs, **kwargs)
  ...
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/json/provider.py", line 120, in _default
    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
TypeError: Object of type DAList is not JSON serializable
```

This PR simply calls `safe_json` on those values, so there aren't extra errors that get logged, even if no user-visible errors happen from the behavior (since refresh isn't doing anything with the checkin json).