### PR TITLE
Remove cpp from workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'javascript', 'python' ]
+        language: [ 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
(note: un-solicited contribution)

It seems that when adding [codeql](https://github.com/jhpyle/docassemble/commit/c4268e330fa504767ec87aa1aaae563aab48fca4), GitHub detected `sample.cpp` in docassemble_demo, and thought that this repo contained C++ code. This isn't correct, and since then, codeql complains loudly that the C++ workflow fails (and sends me silly emails about it).

This removes that workflow. Feel free to clarify if the C++ workflow is intentional and ignore this PR if that is the case.