### PR TITLE
Egg patch

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -19902,6 +19902,7 @@ def get_branches_of_repo(giturl):
     repo_name = re.sub(r'^http.*github.com/', '', repo_name)
     repo_name = re.sub(r'.*@github.com:', '', repo_name)
     repo_name = re.sub(r'.git$', '', repo_name)
+    repo_name = re.sub(r'#egg=(.*)', '', repo_name)
     if app.config['USE_GITHUB']:
         github_auth = r.get('da:using_github:userid:' + str(current_user.id))
     else:

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -16743,9 +16743,10 @@ def update_package():
                 branch = form.gitbranch.data.strip()
                 if not branch:
                     branch = get_master_branch(giturl)
-                m = re.search(r'#egg=(.*)', github_url)
+                m = re.search(r'#egg=(.*)', giturl)
                 if m:
                     packagename = re.sub(r'&.*', '', m.group(1))
+                    giturl = giturl.removesuffix("#egg=" + m.group(1))
                 else:
                     packagename = re.sub(r'/*$', '', giturl)
                     packagename = re.sub(r'^git+', '', packagename)


### PR DESCRIPTION
`github_url` -> `giturl` in the python code.

Update package with any GitHub URL will fail currently. The first commit fixes that and fixes a pip issue that prevents installing packages when there is an `#egg` at the end of the URL. Without it, pip shows the following error:

```
2023-08-22T11:46:34,625 DEPRECATION: git+https://github.com/SuffolkLITLab/ALKiln#egg=docassemble.ALKilnTests.git@v5#egg=docassemble.ALKilnTests contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/11617
2023-08-22T11:46:34,626 ERROR: Invalid requirement: 'docassemble.ALKilnTests.git@v5#egg=docassemble.ALKilnTests'
2023-08-22T11:46:34,626 Hint: = is not a valid operator. Did you mean == ?
```


The second commit makes the JS on the page still work for installing branches, by stripping off `#egg=...` from the URL when sending it to the GitHub API. Without it, all of the branch options are just empty.