### PR TITLE
Put watchdog loop behind `__name__ == '__main__'`

### DIFF
--- a/docassemble_webapp/docassemble/webapp/watchdog.py
+++ b/docassemble_webapp/docassemble/webapp/watchdog.py
@@ -5,33 +5,34 @@ import psutil
 busy_pids = set()
 index = 0
 
-while True:
-    busy_now = set()
-    no_longer_busy = set()
-    for pid in psutil.pids():
-        try:
-            p = psutil.Process(pid)
-            if p.name() in ('apache2', 'uwsgi') and p.cpu_percent(interval=30.0) > 90.0:
-                busy_now.add(pid)
-        except:
-            continue
-    index += 1
-    index = index % 6
-    if index == 5:
-        for pid in busy_pids:
-            if pid not in busy_now:
-                no_longer_busy.add(pid)
-        for pid in no_longer_busy:
-            busy_pids.discard(pid)
-        for pid in busy_now:
-            if pid in busy_pids:
-                try:
-                    p = psutil.Process(pid)
-                    p.kill()
-                except:
-                    pass
-                sys.stderr.write("Killed " + str(pid) + "\n")
+if __name__ == '__main__':
+    while True:
+        busy_now = set()
+        no_longer_busy = set()
+        for pid in psutil.pids():
+            try:
+                p = psutil.Process(pid)
+                if p.name() in ('apache2', 'uwsgi') and p.cpu_percent(interval=30.0) > 90.0:
+                    busy_now.add(pid)
+            except:
+                continue
+        index += 1
+        index = index % 6
+        if index == 5:
+            for pid in busy_pids:
+                if pid not in busy_now:
+                    no_longer_busy.add(pid)
+            for pid in no_longer_busy:
                 busy_pids.discard(pid)
-            else:
-                busy_pids.add(pid)
-    time.sleep(5)
+            for pid in busy_now:
+                if pid in busy_pids:
+                    try:
+                        p = psutil.Process(pid)
+                        p.kill()
+                    except:
+                        pass
+                    sys.stderr.write("Killed " + str(pid) + "\n")
+                    busy_pids.discard(pid)
+                else:
+                    busy_pids.add(pid)
+        time.sleep(5)


### PR DESCRIPTION
I've been using some runtime-introspection tools (particularly [`stubtest`](https://mypy.readthedocs.io/en/stable/stubtest.html)) on docassemble's code base recently, and when you simply `import watchdog`, the tool will get stuck in an infinite loop because the only thing in the file is an infinite `while: True` loop.

This patch puts that behind `if __name__ == '__main__'`, so only people who are running this module as the main module will get the desired infinite loop. The only documented way of running this module is through `run-watchdog.sh`, which runs `python -m docassemble.webapp.watchdog &`, so this shouldn't break any existing functionality.

Tested running in a built docker image, the watchdog process still is running after starting the container, so looks to be all good. 