### PR TITLE
fix DAFile user_access and privilege_access list

### DIFF
--- a/docassemble_webapp/docassemble/webapp/backend.py
+++ b/docassemble_webapp/docassemble/webapp/backend.py
@@ -1181,7 +1181,7 @@ def file_user_access(file_number, allow_user_id=None, allow_email=None, disallow
         db.session.execute(delete(UploadsUserAuth).filter_by(uploads_indexno=file_number))
     if not (allow_user_id or allow_email or disallow_user_id or disallow_email or disallow_all):
         result = {'user_ids': [], 'emails': [], 'temp_user_ids': []}
-        for auth in db.session.execute(select(UploadsUserAuth.user_id, UploadsUserAuth.temp_user_id, UserModel.email).outerjoin(UserModel, UploadsUserAuth.user_id == UserModel.id).where(UploadsUserAuth.uploads_indexno == file_number)).scalars().all():
+        for auth in db.session.execute(select(UploadsUserAuth.user_id, UploadsUserAuth.temp_user_id, UserModel.email).outerjoin(UserModel, UploadsUserAuth.user_id == UserModel.id).where(UploadsUserAuth.uploads_indexno == file_number)).all():
             if auth.user_id is not None:
                 result['user_ids'].append(auth.user_id)
             if auth.temp_user_id is not None:
@@ -1219,7 +1219,7 @@ def file_privilege_access(file_number, allow=None, disallow=None, disallow_all=F
         db.session.execute(delete(UploadsRoleAuth).filter_by(uploads_indexno=file_number))
     if not (allow or disallow or disallow_all):
         result = []
-        for auth in db.session.execute(select(UploadsRoleAuth.id, Role.name).join(Role, UploadsRoleAuth.role_id == Role.id).where(UploadsRoleAuth.uploads_indexno == file_number)).scalars():
+        for auth in db.session.execute(select(UploadsRoleAuth.id, Role.name).join(Role, UploadsRoleAuth.role_id == Role.id).where(UploadsRoleAuth.uploads_indexno == file_number)).all():
             result.append(auth.name)
         return result
     return None


### PR DESCRIPTION
Currently calling `user_access` or `privilege_access` with no args on a DAFile will result in an error. Not sure why but `.scalars()` in this context returns a list containing only the resulting id.
Using `.all()` returns the expected list of `UploadsUserAuth` or `UploadsRoleAuth` objects.

Confirmed broken functionality on the newest version of v1.4.72 on a clean install with the below interview:

```yaml
question: |
  Please upload a picture
fields:
  - Picture: user_picture
    datatype: file
---
code: |
  user_picture[0].privilege_access('user')
  # -----Fails on the below line-----
  got_access = user_picture[0].privilege_access()
---
question: Picture
subquestion: |
  ${ user_picture }
  
  got access: ${ got_access }
mandatory: True
```