### PR TITLE
Update fields.md

### DIFF
--- a/_docs/fields.md
+++ b/_docs/fields.md
@@ -1840,7 +1840,7 @@ When you use the `show if` and `hide if` field modifiers to refer to
 fields that are on the screen, you are able to test whether the fields
 are true, or have particular values, but you cannot do anything more
 complex, such as test whether the value is one of two values, or
-the values of two fields.
+the values of two fields. It is not possible to use `show if:` with wither `hide: if` or `disable if:` on a single field. If you do, the field will be shown regardless of the value of the veriable referred to.
 
 The `js show if` and `js hide if` features allow you to use any
 arbitrary [JavaScript] expression to determine whether a field should


### PR DESCRIPTION
In my use, using show if: with either a hide if: or disable if: (the latter two with different variables than the one in show if:) results in the field being shown regardless of the values of the various variables. I would also propose adding: "If you want to show a field based on the value of one on-screen variable, and hide it based on another on-screen variable, you can implement that using `js show if:`. For example, 

js show if: |
      val('doc.has_hrg') && !val('doc.hrg_is_tbd')

which equates to "if the value of `doc.has_hrg` is True/truthy AND the value of `doc.hrg_is_tbd` is False/falsy, then show the field.