### PR TITLE
Ensure user_dict from DB is string

### DIFF
--- a/docassemble_webapp/docassemble/webapp/backend.py
+++ b/docassemble_webapp/docassemble/webapp/backend.py
@@ -796,7 +796,7 @@ def fetch_user_dict(user_code, filename, secret=None):
     result = db.session.execute(stmt)
     for d in list(result):
         # logmessage("fetch_user_dict: indexno is " + str(d.indexno))
-        if d.dictionary:
+        if d.dictionary and isinstance(d.dictionary, str):
             if d.encrypted:
                 # logmessage("fetch_user_dict: entry was encrypted")
                 user_dict = decrypt_dictionary(d.dictionary, secret)


### PR DESCRIPTION
I have recently seen production errors that are:

```
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/backend.py", line 775, in fetch_user_dict
    user_dict = decrypt_dictionary(d.dictionary, secret)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/backend.py", line 744, in decrypt_dictionary
    decrypter = AES.new(bytearray(secret, encoding='utf-8'), AES.MODE_CBC, dict_string[:16])
TypeError: encoding without a string argument
```

That error occurs when something that isn't a string is passed into `bytearray` with the `encoding` argument.

I have no idea how the `UserDict` could have an entry in a text column that isn't null but also isn't a string, but it seems to have happened. This check will make sure that we don't crash if this happens, and the returned `user_dict` from `fetch_user_dict` will just be `None`.