### PR TITLE
Speed up handling of show if options in questions with lots of fields

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -11887,7 +11887,7 @@ def index(action_argument=None, refer=None):
                 var daThis = this;
                 if (!daShowIfInProcess){
                   daShowIfInProcess = true;
-                  $(":input").not("[type='file']").each(function(){
+                  $("div[data-saveas='" + $(this).data("saveas") + ":input").not("[type='file']").each(function(){
                     if (this != daThis){
                       $(this).trigger('change');
                     }
@@ -12071,7 +12071,7 @@ def index(action_argument=None, refer=None):
               var daThis = this;
               if (!daShowIfInProcess){
                 daShowIfInProcess = true;
-                $(":input").not("[type='file']").each(function(){
+                $("div[data-saveas='" + $(this).data("saveas") + ":input").not("[type='file']").each(function(){
                   if (this != daThis){
                     $(this).trigger('change');
                   }
@@ -14984,7 +14984,7 @@ def observer():
                 var daThis = this;
                 if (!daShowIfInProcess){
                   daShowIfInProcess = true;
-                  $(":input").not("[type='file']").each(function(){
+                  $("div[data-saveas='" + $(this).data("saveas") + ":input").not("[type='file']").each(function(){
                     if (this != daThis){
                       $(this).trigger('change');
                     }
@@ -15168,7 +15168,7 @@ def observer():
               var daThis = this;
               if (!daShowIfInProcess){
                 daShowIfInProcess = true;
-                $(":input").not("[type='file']").each(function(){
+                $("div[data-saveas='" + $(this).data("saveas") + ":input").not("[type='file']").each(function(){
                   if (this != daThis){
                     $(this).trigger('change');
                   }


### PR DESCRIPTION
When a question has a large amount of fields (eg 100), and many of them (eg 50) has a `show if` options that depend on a single field, changing that field gets slow. This is because every show if option ends up as a click event listener on the dependent field, and the final step of that listener, in the ShowHideDiv function, is to trigger the change event on other input fields. The problem is that this results in 50 * 100 calls to `$(this).trigger('change')` instead of the 50 calls for the directly relevant inputs that are needed. The problem grows with both the total amount of fields and the amount of fields that has a show if option (or related options such as `js show if`/`hide if`/`disable if`  etc).

This PR avoids triggering change on every input for every change handler on a field input by rewriting the selectors so that only the input that is directly affected is triggered, resulting in only 50 calls to $(this).trigger('change') in the example above.