### PR TITLE
Make it easier to see API key

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -29948,7 +29948,31 @@ def manage_api():
             if not success:
                 flash(word("Could not create new key"), 'error')
                 return render_template('pages/manage_api.html', **argu)
-            argu['description'] = Markup(word("Your new API key, known internally as <strong>%s</strong>, is:<br />%s<br />") % (form.name.data, "<code>" + api_key + "</code>") + word("<strong>This is the only time you will be able to see your API key</strong>, so make sure to make a note of it and keep it in a secure place."))
+            argu['description'] = Markup(
+                    f"""<div class="alert alert-success" role="alert">
+                    <p>
+                    { word(f"Make sure to copy your <strong>{ form.name.data }</strong> API key now as you will not be able to see this again.") }
+                    </p>
+
+                    Your API key: <kbd id="apiKey">{ api_key }</kbd> <button onclick="copyToClipboard()" class="btn btn-secondary btn-sm">{ word("Copy") }</button>
+                    </div>
+                    
+                    <script>
+                        function copyToClipboard() {{
+                            const apiKeyElement = document.getElementById('apiKey');
+                            const selection = window.getSelection();
+                            const range = document.createRange();
+                            range.selectNodeContents(apiKeyElement);
+                            selection.removeAllRanges();
+                            selection.addRange(range);
+                            document.execCommand('copy');
+                            selection.removeAllRanges();
+                            alert('{ word("API Key copied to clipboard!") }');
+                        }}
+                    </script>
+                    """
+            )
+
         elif action == 'edit':
             argu['title'] = word("Edit API Key")
             argu['tab_title'] = argu['title']


### PR DESCRIPTION
Currently, it is hard to spot an API key on the screen when it is generated. This separates the API key visually with an alert and uses the `kbd` element as opposed to `code` which better indicates the ability to copy and paste.

I've also added a simple copy button.

Visually, I tried to emulate the API key generation appearance from GitHub which is very plain but still easy to read.

New appearance:
![image](https://github.com/jhpyle/docassemble/assets/7645641/869eaa6f-fade-4066-b742-359bbfb6a944)

Comparison to GitHub:

![image](https://github.com/jhpyle/docassemble/assets/7645641/dbb30b1a-1847-43f1-aab2-cfc42285b30b)

Some UX pattern research: https://carbondesignsystem.com/community/patterns/generate-an-api-key/