### PR TITLE
check system version before trying to replace font

### DIFF
--- a/docassemble_base/docassemble/base/pdftk.py
+++ b/docassemble_base/docassemble/base/pdftk.py
@@ -6,6 +6,7 @@ import os
 import string
 import codecs
 import logging
+import packaging
 from io import BytesIO
 from xfdfgen import Xfdf
 import pikepdf
@@ -238,6 +239,11 @@ def fill_template(template, data_strings=None, data_names=None, hidden=None, rea
             font_arguments = ['replacement_font', replacement_font]
         else:
             font_arguments = DEFAULT_FONT_ARGUMENTS
+        system_version = daconfig.get('system version', 'Unknown')
+        if system_version == 'Unknown' or packaging.version.parse(system_version) < packaging.version.parse("1.4.73"):
+          if replacement_font:
+              logmessage("Warning: the `replacement_font` argument isn't supported without a system docassemble of 1.4.73 or above")
+          font_arguments = []
         subprocess_arguments = [PDFTK_PATH, template, 'fill_form', fdf_file.name, 'output', pdf_file.name] + font_arguments
         # logmessage("Arguments are " + str(subprocess_arguments))
         if len(images) > 0:


### PR DESCRIPTION
We ran [into an issue today](https://github.com/mplp/docassemble-Simpmotion/issues/16) where `pdftk` wasn't working. It's because the addition of `replacement_font` in [1.4.79](https://github.com/jhpyle/docassemble/blob/v1.4.79/CHANGELOG.md#1479---2023-09-18) assumes that [installed pdftk version is at least 3.3.0](https://gitlab.com/pdftk-java/pdftk/-/blob/master/CHANGELOG.md?ref_type=heads#330-2021-08-16), which was only the case as of [docassemble system version 1.4.73](https://github.com/jhpyle/docassemble/blob/v1.4.79/CHANGELOG.md#1473---2023-09-04), which includes [docassemble-os 1.0.11](https://github.com/jhpyle/docassemble-os/commit/ffa0522808ed65af7b7a1f7ef9f87c6234e5558f).

IMO that's a bit too soon to expect a docker image update, so I made a patch that checks for the system version, and if it's below 1.4.73, doesn't use replacement fonts. If the user passed in a replacement font specifically, I log a warning. I would have checked the `pdftk` version directly, but it's hidden in a paragraph of other text, and it feels brittle trying to parse the version out of the rest of it.

Still building and testing on an older version of docassemble to make sure it works as expected. Will undraft when it is.