### PR TITLE
Updated certbot to avoid x509 version issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,9 @@ bash -c \
 && pip3 install --upgrade mod_wsgi==4.9.4 \
 && pip3 install --upgrade \
    acme==2.6.0 \
-   certbot==2.6.0 \
-   certbot-apache==2.6.0 \
-   certbot-nginx==2.6.0 \
+   certbot==2.7.0 \
+   certbot-apache==2.7.0 \
+   certbot-nginx==2.7.0 \
    certifi==2023.7.22 \
    cffi==1.15.1 \
    charset-normalizer==3.2.0 \


### PR DESCRIPTION
One of our servers' TLS cert expired, and it looks like something in certbot was the issue. When I tried running it manually, I got the following error:

```
Traceback (most recent call last):
  File "/usr/share/docassemble/local3.10/bin/certbot", line 8, in <module>
    sys.exit(main())
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/main.py", line 15, in main
    return internal_main.main(cli_args)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/_internal/main.py", line 1435, in main
    return config.func(config, plugins)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/_internal/main.py", line 1165, in run
    new_lineage = _get_and_save_cert(le_client, config, domains,
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/_internal/main.py", line 129, in _get_and_save_cert
    renewal.renew_cert(config, domains, le_client, lineage)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/_internal/renewal.py", line 341, in renew_cert
    new_cert, new_chain, new_key, _ = le_client.obtain_certificate(domains, new_key)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/_internal/client.py", line 372, in obtain_certificate
    csr = crypto_util.init_save_csr(key, domains, self.config.csr_dir)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/certbot/crypto_util.py", line 101, in init_save_csr
    csr_pem = acme_crypto_util.make_csr(
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/acme/crypto_util.py", line 252, in make_csr
    csr.set_version(2)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1016, in set_version
    raise ValueError(
ValueError: Invalid version. The only valid version for X509Req is 0.
```

Which led to https://github.com/certbot/certbot/issues/9722. Updating to the latest certbot (2.7.0) and re-running it fixed the issue, so I updated that version in the Dockerfile.

Misc question: is there a way to update the `certbot` and `certbot-nginx` packages after the Docker image is made? I.e. should those packages be added to `setup.py` install requires, so people only need to do a python upgrade instead of a system upgrade or manual fix?