### PR TITLE
Frame search speed optimizations

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -2,7 +2,6 @@ import re
 import types
 import os
 import inspect
-import sys
 import locale
 import decimal
 from io import IOBase
@@ -20,7 +19,7 @@ from enum import Enum
 from pathlib import Path
 import importlib.resources
 import astunparse
-# import sys
+import sys
 import tzlocal
 import us
 import pycountry

--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -2,6 +2,7 @@ import re
 import types
 import os
 import inspect
+import sys
 import locale
 import decimal
 from io import IOBase
@@ -4345,7 +4346,7 @@ def components_of(full_variable):
 
 
 def get_user_dict():
-    frame = inspect.stack()[1][0]
+    frame = sys._getframe(1)
     the_user_dict = frame.f_locals
     while '_internal' not in the_user_dict:
         frame = frame.f_back
@@ -4383,7 +4384,7 @@ def undefine(*pargs, invalidate=False):  # pylint: disable=redefined-outer-name
             raise DAError("undefine: variable " + repr(var) + " is not a valid variable name")
     if len(vars_to_delete) == 0:
         return
-    frame = inspect.stack()[1][0]
+    frame = sys._getframe(1)
     the_user_dict = frame.f_locals
     while '_internal' not in the_user_dict:
         frame = frame.f_back
@@ -4492,7 +4493,7 @@ def _defined_internal(var, caller: DefCaller, alt=None, prior=False):
       user all of the questions necessary to answer it
     * SHOWIFDEF, then the value if returned, but only if no questions have to be asked
     """
-    frame = inspect.stack()[1][0]
+    frame = sys._getframe(1)
     components = components_of(var)
     if len(components) == 0 or len(components[0]) < 2:
         raise DAError("defined: variable " + repr(var) + " is not a valid variable name")


### PR DESCRIPTION
This PR changes all `inspect.stack()[1][0]` to `sys._getframe(1)` which results in an average speed improvement of 5x EACH time the system searches for a variable. For my test interview, on the front end, I saw a 27x speed improvement (from 0.46s to 0.017s) using the same interview, starting a new session each run, and only changing the code in this PR.

Reasoning:
`inspect.stack()` is slow because it collects the entire stack and builds the context for each step, which is then discarded by the stack and frame selection `[1][0]`
I saw a 2x speed improvement just by disabling the context loader with `inspect.stack(0)[1][0]`

Validation:
Using a debugger I verified that the original code gets the frame of the caller this is important because it's recommended to use `inspect.currentframe()` but that gets the current frame (obviously). To get the callers frame the equivalent code would be `inspect.currentframe().f_back`
`inspect.currentframe()` just uses `sys._getframe(1)` and when `sys._getframe(1)` is called it returns the callers frame thus why this PR uses `sys._getframe(1)`
It shouldn't be a problem using the internal method _getframe because it was introduced in Python 2.1 and is well-documented in the current version

References: 
https://stackoverflow.com/a/17407257
https://docs.python.org/3/library/sys.html#sys._getframe

Note: The above debugging and internal timing was done by starting a flask context and calling docassemble.webapp.server.create_new_intreview and docassemble.webapp.server.get_question_data directly.
