### PR TITLE
Keep track of package the bootstrap theme is from

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2153,6 +2153,7 @@ class Question:
                 self.interview.use_tagged_pdf = data['features']['tagged pdf']
             if 'bootstrap theme' in data['features'] and data['features']['bootstrap theme']:
                 self.interview.bootstrap_theme = data['features']['bootstrap theme']
+                self.interview.bootstrap_theme_package = self.package
             if 'inverse navbar' in data['features']:
                 self.interview.options['inverse navbar'] = data['features']['inverse navbar']
             if 'popover trigger' in data['features']:
@@ -7917,7 +7918,10 @@ class Interview:
     def get_bootstrap_theme(self):
         if self.bootstrap_theme is None:
             return None
-        result = docassemble.base.functions.server.url_finder(self.bootstrap_theme, _package=self.source.package)
+        if not hasattr(self, 'bootstrap_theme_package'):
+            result = docassemble.base.functions.server.url_finder(self.bootstrap_theme, _package=self.source.package)
+        else:
+            result = docassemble.base.functions.server.url_finder(self.bootstrap_theme, _package=self.bootstrap_theme_package)
         return result
 
     def get_tags(self, the_user_dict):


### PR DESCRIPTION
This lets us have a `features: bootstrap theme:` block in another package, that we can then include in the current interview. Previously, DA would try to look for a locally referenced bootstrap theme in the current package, i.e. "custom_bootstrap.css" wouldn't work, and you would have to put "docassemble.other_package:custom_bootstrap.css".

Implemented with `hasattr`, since there are a few places that `bootstrap_theme` could come from, and checking for it's existence seemed simpler than adding an extra variable that also tracked where `bootstrap_theme` was set from.

Tested locally and it works as expected.