### PR TITLE
When `prior=true`, keep looking for `old_user_dict`

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -4502,7 +4502,9 @@ def _defined_internal(var, caller: DefCaller, alt=None, prior=False):
     the_user_dict = frame.f_locals
     failure_val = False if caller.is_predicate() else alt
     user_dict_name = 'old_user_dict' if prior else 'user_dict'
-    while variable not in the_user_dict:
+    # When `prior=True`, we need to get `old_user_dict`, but objects could be present in
+    # `the_user_dict` before finding `old_user_dict`. When found, we break, ignoring this condition.
+    while (variable not in the_user_dict) or prior:
         frame = frame.f_back
         if frame is None:
             if caller.is_pure():


### PR DESCRIPTION
If you don't keep looking for `old_user_dict`, you might first reach objects that still exist in the rewound `user_dict`, which might exist, but won't have attributes set before the back button press.

Specifically fixed a bug found when modifying https://docassemble.org/docs/background.html#background_response to be used on an object (at the bottom).

Happy to modify or do any more testing; it seems like it could be a big change, but does seem like the right behavior for `prior=True`.

```yaml
objects:
  - address: Address
---
question: |
  Where do you live?
fields:
  - Country: address.country
    code: countries_list()
  - State: state
    code: |
      states_list(country_code=showifdef('address.country', 'US', prior=True)) or ['N/A']
    js enable if: val('address.country')
check in: update_states_list
---
event: update_states_list
code: |
  if action_argument('_changed') == 'address.country':
    background_response({
      'state': {
        'choices': states_list(country_code=action_argument('address.country')) or ['N/A']
      }
    }, 'fields')
  background_response()
---
mandatory: True
question: |
  You live in
  ${ state_name(state, country_code=address.country) }
  in
  ${ country_name(address.country) }.
subquestion: |
  Your country code is `${ address.country }`.

  Your state code is `${ state }`.
```

Also confirmed that `showifdef` works on the original recipe as expected, and in a few other cases.