### PR TITLE
QR fill

### DIFF
--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1094,7 +1094,7 @@ def qr_url_string(match):
     else:
         alt_text = word("A QR code")
     width_string = "width:" + width
-    im = qrcode.make(string, image_factory=qrcode.image.svg.SvgPathImage)
+    im = qrcode.make(string, image_factory=qrcode.image.svg.SvgPathFillImage)
     output = BytesIO()
     im.save(output)
     the_image = output.getvalue().decode()

--- a/docassemble_base/docassemble/base/filter.py
+++ b/docassemble_base/docassemble/base/filter.py
@@ -1090,9 +1090,9 @@ def qr_url_string(match):
         if match.group(3) != 'None':
             alt_text = str(match.group(3))
         else:
-            alt_text = word("A QR code")
+            alt_text = word(f"A QR code that goes to {string}")
     else:
-        alt_text = word("A QR code")
+        alt_text = word(f"A QR code that goes to {string}")
     width_string = "width:" + width
     im = qrcode.make(string, image_factory=qrcode.image.svg.SvgPathFillImage)
     output = BytesIO()


### PR DESCRIPTION
There are two changes in this PR to make QR codes a bit more accessible.

* add a white fill behind all QR codes using the `SvgPathFillImage` class instead of `SvgPathImage` (both have been in `qrcode` for a while, shouldn't be any version issues). My only other concern is that people might want the background to match the color of their off-white page, but IMO that group is smaller than those using the default light or dark themes. The fill is changeable with JS, changing the `fill` attribute of the `<svg><rect>...` tag. 
* default the alt text of the QR code to include the text of the code itself. I defaulted to "that goes to", since most QR codes are links, but happy to change it something else.

Pre-PR:

![Screenshot of a QR code with black squares on a gray background, barely visible](https://github.com/jhpyle/docassemble/assets/6252212/30fdbec4-23bd-4d71-a159-0d6b9d5210a5)

Post-PR:

![Screenshot of a QR code with black squares with a white fill, on a gray background](https://github.com/jhpyle/docassemble/assets/6252212/b7fd20d1-12d9-462b-972d-2eb889c58d35)


