### PR TITLE
Change `error` attribute back to `ruamel.yaml`

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -8233,7 +8233,7 @@ class Interview:
                     # logmessage(str(source_code))
                     try:
                         # Correct line numbers to be global to the YAML
-                        if isinstance(errMess, safeyaml.error.MarkedYAMLError):
+                        if isinstance(errMess, ruamel.yaml.error.MarkedYAMLError):
                             if errMess.context_mark is not None:
                                 errMess.context_mark.line += (line_number - 1)
                             if errMess.problem_mark is not None:
@@ -8254,7 +8254,7 @@ class Interview:
                     # str(source_code)
                     try:
                         # Correct line numbers to be global to the YAML
-                        if isinstance(errMess, safeyaml.error.MarkedYAMLError):
+                        if isinstance(errMess, ruamel.yaml.error.MarkedYAMLError):
                             if errMess.context_mark is not None:
                                 errMess.context_mark.line += (line_number - 1)
                             if errMess.problem_mark is not None:


### PR DESCRIPTION
The YAML objects don't have the error attribute, and was causing errors when trying to run interviews from the playground. Reverts a few of the lines from https://github.com/jhpyle/docassemble/commit/d30d95eba984d44600c2665bfdc98afb5c601daa.

Stack trace:

```

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/app.py", line 867, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/app.py", line 852, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/server.py", line 6794, in index
    interview = docassemble.base.interview_cache.get_interview(yaml_filename)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/interview_cache.py", line 16, in get_interview
    the_interview = interview_source.get_interview()
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 288, in get_interview
    return Interview(source=self)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 7869, in __init__
    self.read_from(kwargs['source'])
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8267, in read_from
    question = Question(document, self, source=source, package=source_package, source_code=source_code, line_number=line_number)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 3089, in __init__
    self.interview.read_from(interview_source_from_string(questionPath, interview_source=self.interview.source, parent_source=self.from_source))
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8267, in read_from
    question = Question(document, self, source=source, package=source_package, source_code=source_code, line_number=line_number)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 3096, in __init__
    self.interview.read_from(new_source)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8257, in read_from
    if isinstance(errMess, safeyaml.error.MarkedYAMLError):
AttributeError: 'YAML' object has no attribute 'error'
```