### PR TITLE
New feature: `live show if`

### DIFF
--- a/docassemble_base/docassemble/base/data/questions/examples/liveshowif.yml
+++ b/docassemble_base/docassemble/base/data/questions/examples/liveshowif.yml
@@ -1,0 +1,94 @@
+metadata:
+  title: Live show fields with Python
+  short title: live show if
+  documentation: "https://docassemble.org/docs/fields.html#live show if"
+  example start: 1
+  example end: 4
+---
+question: |
+  Please fill in the following information.
+subquestion: |
+  Try setting "Favorite fruit" to 
+  "apple" or "mango" (and unfocus the 
+  field) to see what happens.
+fields:
+  - Favorite fruit: fruit
+  - Favorite vegetable: vegetable
+  - Favorite fungus: mushroom
+    live show if: |
+      fruit == "apple"
+  - Favorite spice: spice
+    live hide if: |
+      fruit == "mango"
+---
+question: |
+  Please fill in the following information.
+subquestion: |
+  See what happens when you set 
+  "Favorite cuisine" to "Chinese food."
+fields:
+  - Favorite cuisine: cuisine
+    choices:
+      - Chinese food
+      - French food
+      - Belgian food
+  - Favorite dish: dish
+    live show if: |
+      cuisine == "Chinese food"
+---
+question: |
+  Please fill in the following information.
+fields:
+  - "Do you watch TV?": watches_tv
+    datatype: yesnoradio
+  - Favorite TV show: tv_show
+    live show if: |
+      watches_tv == true
+  - "I listen to the radio": listens_to_radio
+    datatype: yesno
+  - Favorite radio station: radio_station
+    live show if: |
+      listens_to_radio == true
+  - Favorite modulation type: favorite_modulation
+    datatype: radio
+    choices:
+      - FM
+      - AM
+    live show if: |
+      listens_to_radio == true
+  - Favorite antenna style: favorite_antenna
+    live show if: |
+      favorite_modulation == 'FM'
+---
+question: |
+  Please fill in the following information.
+subquestion: |
+  Try selecting Apple and Plum.
+fields:
+  - Select the fruits you like: liked_fruits
+    datatype: checkboxes
+    choices:
+      - Apple
+      - Peach
+      - Pear
+      - Plum
+  - Favorite way to eat apples and plums: apple_plum_dish
+    live show if: |
+      liked_fruits['Apple'] and liked_fruits['Plum']
+---
+question: |
+  Thank you for that information.
+subquestion: |
+  You like ${ fruit },
+  ${ cuisine }.
+  
+  % if watches_tv:
+  Your favorite TV show is ${ tv_show }.
+  % endif
+
+  % if listens_to_radio:
+  Your favorite radio station is ${ radio_station }.
+  % endif
+  
+  You like ${ liked_fruits.true_values() }.
+mandatory: True

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -77,7 +77,7 @@ def da_js_name(t, x):
   cls = {'True': JSTrue, 'False': JSFalse,}.get(x.id)
   if cls:
     return cls()
-  # yesnounknown radios return "None" the string, so we need to match python's semantics to what that expects
+  # yesnomaybe radios return "None" the string, so we need to match python's semantics to what that expects
   if x.id == "None":
     return JSStr("None")
   else:
@@ -90,7 +90,7 @@ def da_js_name_constant(t, x):
   cls = {True: JSTrue, False: JSFalse,}.get(x.value)
   if cls:
     return cls()
-  # yesnounknown radios return "None" the string, so we need to match python's semantics to what that expects
+  # yesnomaybe radios return "None" the string, so we need to match python's semantics to what that expects
   return JSStr("None")
 
 metapensiero.pj.transformations.obvious.Name_default = da_js_name
@@ -776,8 +776,9 @@ class InterviewStatus:
                                 self.extras['show_if_js'][the_field.number]['expression'] = re.sub(iterator_re, '[' + str(list_indexno) + ']', self.extras['show_if_js'][the_field.number]['expression'])
                             if the_field.extras['show_if_js']['expression'].uses_mako:
                                 the_field.extras['show_if_js']['expression'].template = MakoTemplate(the_field.extras['show_if_js']['expression'].original_text, strict_undefined=True, input_encoding='utf-8')
+                            # NOTE: If the user is trying to dynamically add the names of vars with Mako, the below won't work.
                             js_expr = the_field.extras['show_if_js']['expression'].text()
-                            if the_field.extras['show_if_js']['is_python']:
+                            if the_field.extras['show_if_js'].get('is_python'):
                               js_expr = transform_string(js_expr)
                             the_field.extras['show_if_js']['vars'] = process_js_vars(re.findall(r'(?:val|getField|daGetField)\(\'([^\)]+)\'\)', js_expr) + re.findall(r'(?:val|getField|daGetField)\("([^\)]+)"\)', js_expr))
                             for ii in range(len(the_field.extras['show_if_js']['vars'])):
@@ -6022,11 +6023,11 @@ class Question:
                     if 'show_if_js' in field.extras:
                         if 'show_if_js' not in extras:
                             extras['show_if_js'] = {}
-                        js_expr = field.extras['show_if_js']['expression'].text()
+                        js_expr = field.extras['show_if_js']['expression'].text(user_dict)
                         if field.extras['show_if_js'].get('is_python'):
                             js_expr = transform_string(js_expr)
                         field.extras['show_if_js']['vars'] = process_js_vars(re.findall(r'(?:val|getField|daGetField)\(\'([^\)]+)\'\)', js_expr) + re.findall(r'(?:val|getField|daGetField)\("([^\)]+)"\)', js_expr))
-                        extras['show_if_js'][field.number] = {'expression': field.extras['show_if_js']['expression'].text(user_dict), 'vars': copy.deepcopy(field.extras['show_if_js']['vars']), 'sign': field.extras['show_if_js']['sign'], 'mode': field.extras['show_if_js']['mode']}
+                        extras['show_if_js'][field.number] = {'expression': js_expr, 'vars': copy.deepcopy(field.extras['show_if_js']['vars']), 'sign': field.extras['show_if_js']['sign'], 'mode': field.extras['show_if_js']['mode']}
                     if 'field metadata' in field.extras:
                         if 'field metadata' not in extras:
                             extras['field metadata'] = {}

--- a/docassemble_base/setup.py
+++ b/docassemble_base/setup.py
@@ -129,6 +129,7 @@ install_requires = [
     "isodate==0.6.1",
     "itsdangerous==2.1.2",
     "jaraco.classes==3.3.0",
+    "javascripthon==0.12",
     "jdcal==1.4.1",
     "jeepney==0.8.0",
     "jellyfish==0.11.2",


### PR DESCRIPTION
As previewed in slack, this PR introduces a new feature, called `live show if`. It works like `js show if`, but it lets users write python expressions as they would in a code block instead. It uses a simple[^1] JavaScript to python transpiler to convert python operations and expressions to JavaScript, and by monkey-patching that library by wrapping python variable references in `val("...")`.


## Use

In a YAML file, it's use looks something like this:

```
question: attribute test
fields:
  - Type goodbye: da_var
  - note: |
      See you later!
    live show if: da_var == "goodbye"
```

## Technical Implementation

On the backend, when the `parse.py` module is loaded, it loads the `metapensiero.pj.__main__.transform_string`, overriding a few functions that convert the python AST to JavaScript's:

* Attribute access (`da_obj.attribute`), subscripts (`da_list[1]` or `da_dict["key"]`), and simple variable names get wrapped in `val("...")` in JavaScript.
* As seen in [this js show if recipe](https://docassemble.org/docs/recipes.html#js%20show%20if%20yesnomaybe), `yesnomaybe` return the string `"None"` for python's None, instead of JavaScript's `null`. We override to preserve this behavior. Someone could certainly write a python expression that uses `None` that shouldn't be the string `"None"`, but it seems unlikely since you are restricted to variables on the page, where `None` is only used for those select cases.

The only substantial modification to existing code is that we can't transpile python to JS if that python still has Mako present, and we need to transpile the expressions before finding what variables are present in it. So I moved the search for variables later in the process. I think this adds a bit of runtime per screen as opposed to per interview load, but it's necessary, and in my testing didn't slow down things extensively.

On the frontend, it uses all of the same JavaScript as the `js show if` does, so no changes there.

## Other considerations

The biggest consideration is the addition and monkey patching of the `javascripthon` or `metapensiero.pj` library as a dependency. From the [TODO](https://github.com/metapensiero/metapensiero.pj#table-of-contents) section of it's README, there aren't any major refactors, or any changes mentioned for the few places that we override, so IMO it's not too extensive of a change for our uses. It definitely a choice to be made though, so I'll leave it to you. I've added a demo here, and if this gets accepted, I'll make another PR documenting this further.

[^1]: Simple as compared to heavier ways to run python in the browser, such as `brython` or `pyodide`, which require a lot of extra javascript to be delivered to the user and make different assumptions about where the python variables referenced actually are.