### PR TITLE
Allow customizing title to add HTML without breaking meta tags

### DIFF
--- a/docassemble_webapp/docassemble/webapp/templates/base_templates/base.html
+++ b/docassemble_webapp/docassemble/webapp/templates/base_templates/base.html
@@ -12,7 +12,7 @@
     <meta name="{{ key }}" content="{{ config['SOCIAL'][key] }}">
 {%- endif %}
 {%- endfor %}
-    <meta itemprop="name" content="{% if page_title %}{{ config['BRAND_NAME'] }}: {{ page_title }}{% else %}{{ config['BRAND_NAME'] }}{% endif %}">
+    <meta itemprop="name" content="{% if page_title %}{{ config['BRAND_NAME'] }}: {{ page_title | striptags | e }}{% else %}{{ config['BRAND_NAME'] }}{% endif %}">
 {%- if 'description' in config['SOCIAL'] %}
     <meta itemprop="description" content="{{ config['SOCIAL']['description'] }}">
 {%- endif %}
@@ -27,9 +27,9 @@
     <meta name="twitter:{{ key }}" content="{{ config['SOCIAL']['twitter'][key] }}">
 {%- endif %}
 {%- endfor %}
-    <meta name="twitter:title" content="{% if page_title %}{{ config['BRAND_NAME'] }}: {{ page_title }}{% else %}{{ config['BRAND_NAME'] }}{% endif %}">
+    <meta name="twitter:title" content="{% if page_title %}{{ config['BRAND_NAME'] }}: {{ page_title | striptags | e  }}{% else %}{{ config['BRAND_NAME'] }}{% endif %}">
 {%- if 'image' in config['SOCIAL']['og'] %}
-    <meta name="og:title" content="{% if page_title %}{{ config['BRAND_NAME'] }}: {{ page_title }}{% else %}{{ config['BRAND_NAME'] }}{% endif %}">
+    <meta name="og:title" content="{% if page_title %}{{ config['BRAND_NAME'] }}: {{ page_title | striptags | e  }}{% else %}{{ config['BRAND_NAME'] }}{% endif %}">
 {%- for key in config['SOCIAL']['og'] %}
 {%- if key not in ('locale', 'url') %}
     <meta name="og:{{ key }}" content="{{ config['SOCIAL']['og'][key] }}">


### PR DESCRIPTION
While trying to help a developer customize the logo in the top left of the register/sign-in page, we were getting the logo tripled.

After digging through `docassemble_webapp/docassemble/webapp/templates/base_templates/base.html` it appears that the `register page title` overrides `page_title` which in turn is used to customize `<meta itemprop="name"...`, `<meta name="twitter:...`, and `<meta name="og:title"...>`, but there is no escaping done to remove HTML.

It seems that while `page_title` is fine to have HTML, these specific places it is doubled-up shouldn't get nested HTML. If the included HTML in `... page title` configuration includes quotes, the HTML is broken and doesn't render properly.

This PR removes the first-level HTML and then escapes any other potentially problematic entities that might remain so the `...page title` configuration can safely include HTML without breaking the dual-uses.