### PR TITLE
Add "use div as legend" config and features value

### DIFF
--- a/docassemble_base/docassemble/base/config.py
+++ b/docassemble_base/docassemble/base/config.py
@@ -996,6 +996,10 @@ def load(**kwargs):
         daconfig['web server'] = 'nginx'
     if 'table css class' not in daconfig or not isinstance(daconfig['table css class'], str):
         daconfig['table css class'] = 'table table-striped'
+    if 'use div as legend' in daconfig:
+        if not isinstance(daconfig['use div as legend'], bool):
+            config_error('The Configuration directive "use div as legend" must be True or False.')
+            del daconfig['use div as legend']
     if env_true_false('ENVIRONMENT_TAKES_PRECEDENCE'):
         messages = []
         for env_var, key in (('DBPREFIX', 'prefix'), ('DBNAME', 'name'), ('DBUSER', 'user'), ('DBPASSWORD', 'password'), ('DBHOST', 'host'), ('DBPORT', 'port'), ('DBTABLEPREFIX', 'table prefix'), ('DBBACKUP', 'backup'), ('DBSSLMODE', 'ssl mode'), ('DBSSLCERT', 'ssl cert'), ('DBSSLKEY', 'ssl key'), ('DBSSLROOTCERT', 'ssl root cert')):

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2260,6 +2260,10 @@ class Question:
                 self.interview.options['hide standard menu'] = data['features']['hide standard menu']
             if 'labels above fields' in data['features'] and isinstance(data['features']['labels above fields'], bool):
                 self.interview.options['labels above'] = data['features']['labels above fields']
+            if 'use div as legend' in data['features']:
+                if not isinstance(data['features']['use div as legend'], bool):
+                    raise DASourceError('"use div as legend" in the "features" block must be either True or False.' + self.idebug(data))
+                self.interview.options['use div as legend'] = data['features']['use div as legend']
             if 'suppress autofill' in data['features'] and isinstance(data['features']['suppress autofill'], bool):
                 self.interview.options['suppress autofill'] = data['features']['suppress autofill']
             if 'floating labels' in data['features'] and isinstance(data['features']['floating labels'], bool):

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -11684,7 +11684,7 @@ def index(action_argument=None, refer=None):
         var daPopoverList = daPopoverTriggerList.map(function (daPopoverTriggerEl) {
           return new bootstrap.Popover(daPopoverTriggerEl, {trigger: """ + json.dumps(interview.options.get('popover trigger', 'focus')) + """, html: true});
         });
-        $('label a[data-bs-toggle="popover"], legend a[data-bs-toggle="popover"]').on('click', function(event){
+        $('label a[data-bs-toggle="popover"], legend a[data-bs-toggle="popover"], div[id*="_fieldset_label"] a[data-bs-toggle="popover"]').on('click', function(event){
           event.preventDefault();
           event.stopPropagation();
           var thePopover = bootstrap.Popover.getOrCreateInstance(this);

--- a/docassemble_webapp/docassemble/webapp/static/app/app.css
+++ b/docassemble_webapp/docassemble/webapp/static/app/app.css
@@ -219,7 +219,8 @@ i.da-chat-inactive:hover {
     margin-right: calc(var(--bs-gutter-x) * .5);
 }
 
-.da-grid-container.da-form-group-floating legend {
+.da-grid-container.da-form-group-floating legend,
+.da-grid-container.da-form-group-floating [id*="_fieldset_label"] {
     margin-left: calc(var(--bs-gutter-x) * .5);
     margin-right: calc(var(--bs-gutter-x) * .5);
 }
@@ -244,7 +245,8 @@ i.da-chat-inactive:hover {
     color: var(--bs-red);
 }
 
-legend.da-top-label {
+legend.da-top-label,
+[id*="_fieldset_label"].da-top-label {
     font-size: inherit;
 }
 
@@ -789,7 +791,8 @@ div.dafieldpart > label:first-of-type {
     margin-top: 0px;
 }
 
-div.dafieldpart > legend:first-of-type {
+div.dafieldpart > legend:first-of-type,
+div.dafieldpart > [id*="_fieldset_label"]:first-of-type {
     margin-top: 0px;
 }
 
@@ -957,7 +960,8 @@ img.da-sig-spinner {
     width: 100%;
 }
 
-.dafullwidth + legend {
+.dafullwidth + legend,
+.dafullwidth + [id*="_fieldset_label"] {
     width: 100%;
 }
 

--- a/tests/features/steps/docassemble.py
+++ b/tests/features/steps/docassemble.py
@@ -513,10 +513,10 @@ def set_text_box_alt(context, num, value):
 @step(r'I click the "(?P<option>[^"]+)" option under "(?P<label>[^"]+)"')
 def set_mc_option_under(context, option, label):
     try:
-        div = context.browser.find_element(By.XPATH, '//legend[text()="' + label + '"]/following-sibling::div')
+        div = context.browser.find_element(By.XPATH, '//*[contains(@id, "fieldset_label")][text()="' + label + '"]/following-sibling::div')
     except:
         label += " "
-        div = context.browser.find_element(By.XPATH, '//legend[text()="' + label + '"]/following-sibling::div')
+        div = context.browser.find_element(By.XPATH, '//*[contains(@id, "fieldset_label")][text()="' + label + '"]/following-sibling::div')
     try:
         span = div.find_element(By.XPATH, './/span[text()="' + option + '"]')
     except:
@@ -538,10 +538,10 @@ def set_mc_option(context, choice):
 @step(r'I click the option "(?P<option>[^"]+)" under "(?P<label>[^"]+)"')
 def set_mc_option_under_pre(context, option, label):
     try:
-        div = context.browser.find_element(By.XPATH, '//legend[text()="' + label + '"]/following-sibling::div')
+        div = context.browser.find_element(By.XPATH, '//*[contains(@id, "fieldset_label")][text()="' + label + '"]/following-sibling::div')
     except:
         label += " "
-        div = context.browser.find_element(By.XPATH, '//legend[text()="' + label + '"]/following-sibling::div')
+        div = context.browser.find_element(By.XPATH, '//*[contains(@id, "fieldset_label")][text()="' + label + '"]/following-sibling::div')
     try:
         span = div.find_element(By.XPATH, './/span[text()="' + option + '"]')
     except:


### PR DESCRIPTION
Let devs replace visible `legend` elems with `div`. Follows accessibility guidelines by using `aria-labelledby` and `id`.

Devs can set "use div as legend" in the config file or the same key in the features block to a boolean. The feature block value takes precedence. This will change the visible HTML legend elements to divs. If the dev uses anything other than a boolean, they get an error message.

The motivation is Safari's (old and current) desktop versions and some user testing. Bootstrap says it supports current versions of Safari and that's correct - this isn't a direct Bootstrap problem. It's about the HTML is put together and which of Bootstrap's features are used there. With HTML that has a `legend` that uses Bootstrap's flexbox styles,  Safari desktop handles those `legend` nodes incorrectly. The `legend` text is above the choices and right-aligned:

![image](https://github.com/user-attachments/assets/1db0b3fe-5583-401f-b653-1b1a136e63ce)

User tests found that this visual was confusing. @VTskier might be able to speak about that.

This change fixes that issue with minimal side effects. Here is [a decision matrix that I've shared](https://docs.google.com/spreadsheets/d/1lGg5olFHDZa0lNooOIgisqZxZ2oY9YHpfe5bT7h_dhY/edit?usp=sharing).

Why allow both config and feature block keys? If a server has multiple organizations, as Suffolk's server does, different orgs might want to control their own settings.

Why change only visible legend elements? It is a smaller change and I thought it would be less trouble to review.

Why ensure always unique random ids? Devs should not rely on the selector. Avoids later breaking changes.

## Manual tests

Outcomes of tests for configuration combinations:

| config | feature | result |
| - | - | - |
| absent | absent | legend |
| *false* | absent | legend |
| **true** | absent | div |
| absent | **true** | div |
| *false* | **true** | div |
| **true** | **true** | div |
| absent | *false* | legend |
| *false* | *false* | legend |
| **true** | *false* | legend |
| <ins>chair</ins> | absent | legend |
| <ins>chair</ins> | *false* | legend |
| <ins>chair</ins> | **true** | div |

Tests for error messages:

| where | value | error location | error message |
| - | - | - | - |
| config | chair | websockets.log | The Configuration directive "use div as legend" must be True or False. |
| feature | chair | webpage | "use div as legend" in the "features" block must be either True or False. |

## Relevant files

Edited:

- docassemble_base/docassemble/base/config.py
- docassemble_base/docassemble/base/parse.py
- docassemble_base/docassemble/base/standardformatter.py
- docassemble_webapp/docassemble/webapp/static/app/app.css
- docassemble_webapp/docassemble/webapp/server.py
- tests/features/TestExamples.feature

Ignored:

- docassemble_demo/docassemble/demo/data/static/lumen.min.css: Disabling the styles in the DOM didn't have an effect.
- docassemble_webapp/docassemble/webapp/static/bootstrap/css/bootstrap.min.css: Same styles as lumen.
- docassemble_webapp/docassemble/webapp/static/app/cm6.js: Treats `div` and `legend` the same.
- docassemble_webapp/docassemble/webapp/static/app/jquery.min.js: jQuery uses `legend` in checks for disabled fields. Both `div` and `legend` cannot be disabled and from what I saw in the code I believe jQuery would treat them the same way: https://github.com/jquery/jquery/blob/03e183c4ccf22bf4031920c3270c9f113cb72d1d/src/selector.js#L277 jQuery mentions the spec for disableable elements: https://github.com/jquery/jquery/blob/03e183c4ccf22bf4031920c3270c9f113cb72d1d/src/selector.js#L248-L250
- docassemble_webapp/docassemble/webapp/static/app/MaterialIcons-Regular.json: MaterialIcons icons are independent of the html that uses them.

Compiled files (ignored):

- docassemble_webapp/docassemble/webapp/static/app/adminbundle.js
- docassemble_webapp/docassemble/webapp/static/app/app.min.css
- docassemble_webapp/docassemble/webapp/static/app/bundle.css
- docassemble_webapp/docassemble/webapp/static/app/bundle.js
- docassemble_webapp/docassemble/webapp/static/app/cm6.min.js
- docassemble_webapp/docassemble/webapp/static/bootstrap/css/bootstrap.min.css.map

I found no appearances of "disabled" associated with legends.