### PR TITLE
avoid calling fix_subdoc twice (only in include_docx_template)

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -7147,8 +7147,6 @@ class Question:
                                 # Copy over images, etc from subdoc to master template
                                 subdocs = docassemble.base.functions.this_thread.misc.get('docx_subdocs', [])  # Get the subdoc file list
                                 the_template_docx = the_template.docx
-                                for subdoc in subdocs:
-                                    docassemble.base.file_docx.fix_subdoc(the_template_docx, subdoc)
 
                             except TemplateError as the_error:
                                 if (not hasattr(the_error, 'filename')) or the_error.filename is None:


### PR DESCRIPTION
This fixes #805 (but may have other side effects -- but it seems safer to run fix_subdoc before render since render may cause dangling bookmarkEnd tags, that renumber_bookmarks() then will renumber incorrectly).