### PR TITLE
Update `install_requires` dependency docs to example from pip >= 19

### DIFF
--- a/_docs/packages.md
+++ b/_docs/packages.md
@@ -270,11 +270,10 @@ system knows where to find the package.  For example, if
 include:
 
 {% highlight python %}
-install_requires=['docassemble.helloworld', 'kombu'],
-dependency_links=['git+https://github.com/jhpyle/docassemble-helloworld#egg=docassemble.helloworld-0.1'],
+install_requires=['docassemble-helloworld @ https://github.com/jhpyle/docassemble-helloworld/archive/main.zip', 'kombu'],
 {% endhighlight %}
 
-If you use the [Packages area] of the [Playground] to maintain your
+This is just one example. Different dependency situations might require a more advanced understanding of [pip's `install_requires` dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers). If you use the [Packages area] of the [Playground] to maintain your
 package, this is all handled for you.
 
 # <a name="installing"></a>Installing a package


### PR DESCRIPTION
Edit: This tweak was based on the assumption that this section of the documentation was for packages one installs and works on in the Playground. That may be incorrect. Here's [some other documentation (about Playground packages) that jhpyle pointed me to](https://docassemble.org/docs/playground.html#packages). These two may or may not be related. That's unclear to me now. I'll leave my PR in case it's still relevant, but this might not be accurate. I'd be happy to edit it once I understand better.

---

Apparently `dependency_links` got removed with version 19. Instead, you put the information in `install_requires` with special formatting. This format worked for me to install a GitHub dependency during ALKiln test runs:

```
install_requires=['github-package-name @ git+https://github.com/user/github-package-name']
```

See https://stackoverflow.com/a/54793503

> The --process-dependency-links option to enable dependency_links was removed in Pip 19.0.
> 
> Instead, you can use a PEP 508 URL to specify your dependency, which is supported since Pip 18.1. Here's an example excerpt from setup.py:
> 
> ```py
> install_requires=[
>     "numpy",
>     "package1 @ git+https://github.com/user1/package1",
>     "package2 @ git+https://github.com/user2/package2@branch1",
> ],
> ```
> Note that Pip does not support installing packages with such dependencies from PyPI and in the future you will not be able to upload them to PyPI (see news entry for Pip 18.1).

It seems a little different in the specification docs (https://packaging.python.org/en/latest/specifications/dependency-specifiers/#examples)

> A minimal URL based lookup:
> 
> ```py
> pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686
> ```