### PR TITLE
feat: add input type 'datalist' to fields

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -4013,7 +4013,7 @@ class Question:
                             raise DASourceError("An ajax field must have an associated action." + self.idebug(data))
                         if 'choices' in field or 'code' in field:
                             raise DASourceError("An ajax field cannot contain a list of choices except through an action." + self.idebug(data))
-                    if field['input type'] in ('radio', 'combobox', 'pulldown') and not ('choices' in field or 'code' in field):
+                    if field['input type'] in ('radio', 'combobox', 'datalist', 'pulldown') and not ('choices' in field or 'code' in field):
                         raise DASourceError("A multiple choice field must refer to a list of choices." + self.idebug(data))
                 if len(field) == 1 and 'code' in field:
                     field_info['type'] = 'fields_code'
@@ -6284,7 +6284,7 @@ class Question:
                     only_empty_fields_exist = True
                 commands_to_run = []
                 for field in self.fields:
-                    if hasattr(field, 'inputtype') and field.inputtype == 'combobox':
+                    if hasattr(field, 'inputtype') and field.inputtype in ('combobox', 'datalist'):
                         only_empty_fields_exist = False
                     docassemble.base.functions.this_thread.misc['current_field'] = field.number
                     if hasattr(field, 'has_code') and field.has_code:

--- a/docassemble_base/docassemble/base/standardformatter.py
+++ b/docassemble_base/docassemble/base/standardformatter.py
@@ -3187,6 +3187,8 @@ def input_for(status, field, embedded=False, floating_label=None):
                 daobject = ''
             if hasattr(field, 'inputtype') and field.inputtype == 'combobox' and defaultvalue:
                 datadefault = ' data-default=' + fix_double_quote(str(defaultvalue))
+            elif hasattr(field, 'inputtype') and field.inputtype == 'datalist' and defaultvalue:
+                datadefault = ' value=' + fix_double_quote(str(defaultvalue))
             else:
                 datadefault = ''
             if embedded:
@@ -3202,11 +3204,26 @@ def input_for(status, field, embedded=False, floating_label=None):
                     if floating_label:
                         emb_text += ' da-combobox-floating'
                     emb_text += '" '
+                elif hasattr(field, 'inputtype') and field.inputtype == 'datalist':
+                    emb_text = 'class="form-control' + daobject
+                    if floating_label:
+                        emb_text += ' da-datalist-floating'
+                    emb_text += '" '
                 else:
                     emb_text = 'class="form-select dasingleselect' + daobject + '" '
             if embedded:
                 output += '<span class="da-inline-error-wrapper">'
-            output += '<select ' + emb_text + 'name="' + escape_id(saveas_string) + '"' + datadefault + ' id="' + escape_id(saveas_string) + '" ' + disable_others_data + req_attr + disabled_attr + '>'
+            if hasattr(field, 'inputtype') and field.inputtype == 'datalist':
+                input_type = 'text'
+                if hasattr(field, 'datatype'):
+                    if field.datatype == 'integer':
+                        input_type = 'number'
+                        emb_text += ' step="1"'
+                    elif field.datatype in ('number', 'float'):
+                        input_type = 'number'
+                output += '<input type="' + input_type + '" list="' + escape_id(saveas_string) + 'list" ' + emb_text + 'name="' + escape_id(saveas_string) + '"' + datadefault + ' id="' + escape_id(saveas_string) + '" ' + placeholdertext + disable_others_data + req_attr + disabled_attr + '><datalist id="' + escape_id(saveas_string) + 'list">'
+            else:
+                output += '<select ' + emb_text + 'name="' + escape_id(saveas_string) + '"' + datadefault + ' id="' + escape_id(saveas_string) + '" ' + disable_others_data + req_attr + disabled_attr + '>'
             first_option = ''
             if hasattr(field, 'inputtype') and field.inputtype == 'combobox' and not embedded:
                 if placeholdertext == '':
@@ -3215,6 +3232,8 @@ def input_for(status, field, embedded=False, floating_label=None):
                     first_option += '<option value=""></option>'
                 else:
                     first_option += '<option value="">' + option_escape(str(status.hints[field.number].replace('\n', ' '))) + '</option>'
+            elif hasattr(field, 'inputtype') and field.inputtype == 'datalist' and not embedded:
+                pass
             else:
                 if placeholdertext == '':
                     first_option += '<option value="">' + option_escape(word('Select...')) + '</option>'
@@ -3263,10 +3282,14 @@ def input_for(status, field, embedded=False, floating_label=None):
             if (not status.extras['required'][field.number]) or (not found_default):
                 output += first_option
             output += other_options
-            if embedded:
-                output += '</select></span> '
+            if hasattr(field, 'inputtype') and field.inputtype == 'datalist':
+                output += '</datalist>'
             else:
-                output += '</select> '
+                output += '</select>'
+            if embedded:
+                output += '</span> '
+            else:
+                output += ' '
     elif hasattr(field, 'datatype'):
         if field.datatype == 'boolean' and not is_hidden:
             label_text = markdown_to_html(status.labels[field.number], trim=True, status=status, strip_newlines=True, escape=(not embedded), do_terms=False)


### PR DESCRIPTION
This PR adds support for the HTML5 `datalist` as an input type for fields.

I propose adding `datalist` as an alternative input type to `combobox`. They fill very similar niches, but `datalist` is a standard HTML5 supported tag which requires no additional JavaScript, has better accessibility, and has wide browser support.

In docassemble, I specifically ensure support for `hint` and `number`/`integer` datatypes.

You can try a basic example of a `datalist` on the [W3Schools Tryit Editor](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_datalist) and you can see a Bootstrap example [in their docs](https://getbootstrap.com/docs/5.2/forms/form-control/#datalists).

Some webpages that support the addition of `datalist`:
["Datalist over ARIA combobox"](https://www.webaxe.org/datalist-over-aria-combobox/)
[Datalist browser support](https://caniuse.com/datalist)
[Datalist accessibility support](https://a11ysupport.io/tech/html/datalist_element)