### PR TITLE
fix: update Python venv references to align with changes in v1.7.0, `3.10` -> `3.12`

### DIFF
--- a/_docs/api.md
+++ b/_docs/api.md
@@ -3715,8 +3715,8 @@ function.
 [`/api/session`]: #session_post
 [`/api/session/new`]: #session_new
 [`/api/session/question`]: #session_question
-[Python dict]: https://docs.python.org/3.10/tutorial/datastructures.html#dictionaries
-[Python objects]: https://docs.python.org/3.10/tutorial/classes.html
+[Python dict]: https://docs.python.org/3.12/tutorial/datastructures.html#dictionaries
+[Python objects]: https://docs.python.org/3.12/tutorial/classes.html
 [`all_variables()`]: {{ site.baseurl }}/docs/functions.html#all_variables
 [`url_args`]: {{ site.baseurl }}/docs/special.html#url_args
 [`multi_user`]: {{ site.baseurl }}/docs/special.html#multi_user
@@ -3747,7 +3747,7 @@ function.
 [`/api/package`]: #package_install
 [pip]: https://en.wikipedia.org/wiki/Pip_%28package_manager%29
 [302 redirect]: https://en.wikipedia.org/wiki/HTTP_302
-[pickle]: https://docs.python.org/3.10/library/pickle.html
+[pickle]: https://docs.python.org/3.12/library/pickle.html
 [`required privileges`]: {{ site.baseurl }}/docs/initial.html#required privileges
 [YAML]: https://en.wikipedia.org/wiki/YAML
 [sample-form.pdf]: {{ site.github.repository_url }}/blob/master/docassemble_base/docassemble/base/data/templates/sample-form.pdf

--- a/_docs/background.md
+++ b/_docs/background.md
@@ -1520,7 +1520,7 @@ privileges and user identity of the [cron user].
 [Python set]: https://docs.python.org/3/library/stdtypes.html#set
 [`DALazyTemplate`]: {{ site.baseurl }}/docs/objects.html#DALazyTemplate
 [HTML]: https://en.wikipedia.org/wiki/HTML
-[list]: https://docs.python.org/3.10/tutorial/datastructures.html
+[list]: https://docs.python.org/3.12/tutorial/datastructures.html
 [dict]: https://docs.python.org/3/library/stdtypes.html#dict
 [evaluates the interview]: {{ site.baseurl }}/docs/logic.html
 [`reload` modifier]: {{ site.baseurl }}/docs/modifiers.html#reload

--- a/_docs/config.md
+++ b/_docs/config.md
@@ -6584,7 +6584,7 @@ and Facebook API keys.
 [`docassemble.webapp.install_certs`]: {{ site.github.repository_url }}/blob/master/docassemble_webapp/docassemble/webapp/install_certs.py
 [`brandname`]: #brandname
 [`appname`]: #appname
-[PYTHONUSERBASE]: https://docs.python.org/3.10/using/cmdline.html#envvar-PYTHONUSERBASE
+[PYTHONUSERBASE]: https://docs.python.org/3.12/using/cmdline.html#envvar-PYTHONUSERBASE
 [Apache]: https://en.wikipedia.org/wiki/Apache_HTTP_Server
 [HTTPS]: {{ site.baseurl }}/docs/docker.html#https
 [startup process]: {{ site.github.repository_url }}/blob/master/Docker/initialize.sh

--- a/_docs/development.md
+++ b/_docs/development.md
@@ -622,20 +622,20 @@ source code is located.
 The second complication is that you need to install the [Python]
 packages in the right place, using the right file permissions.  On
 your server, your **docassemble** server will be running in a [Python
-virtual environment] located in `/usr/share/docassemble/local3.10` (unless
+virtual environment] located in `/usr/share/docassemble/local3.12` (unless
 you significantly deviated from the standard installation procedures).
 The files in this folder will all be owned by `www-data`.  The [uWSGI]
 web server process that runs the **docassemble** code runs as this
 user.  The files in the virtual environment are owned by `www-data` so
 that you can use the web application to install and upgrade [Python]
 packages.  If you change the ownership of any of the files in
-`/usr/share/docassemble/local3.10` to `root` or another user, you may get
+`/usr/share/docassemble/local3.12` to `root` or another user, you may get
 errors in the web application.  When using `pip` from the command line
 to install your own version of the **docassemble** packages, you need
 to first become `www-data` by running `su www-data` as root.  Then you
 need to tell `pip` that you are using a specific [Python virtual
 environment] by running `source
-/usr/share/docassemble/local3.10/bin/activate`.  Then, you can run `pip`
+/usr/share/docassemble/local3.12/bin/activate`.  Then, you can run `pip`
 to install your altered version of the **docassemble** code.  This
 line will install all the packages:
 
@@ -690,9 +690,9 @@ Here are the contents of `www-compile.sh`:
 {% highlight bash %}
 #! /bin/bash
 source /etc/profile
-source /usr/share/docassemble/local3.10/bin/activate
+source /usr/share/docassemble/local3.12/bin/activate
 pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo ./docassemble && touch /usr/share/docassemble/webapp/docassemble.wsgi
-history -s "source /usr/share/docassemble/local3.10/bin/activate"
+history -s "source /usr/share/docassemble/local3.12/bin/activate"
 history -s "pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo ./docassemble && touch /usr/share/docassemble/webapp/docassemble.wsgi"
 {% endhighlight %}
 

--- a/_docs/docker.md
+++ b/_docs/docker.md
@@ -983,7 +983,7 @@ If you need to make manual changes to the installation of [Python]
 packages, note that **docassemble**'s [Python] code is installed in a
 [Python virtual environment] in which all of the files are readable
 and writable by the `www-data` user. The virtual environment is
-located at `/usr/share/docassemble/local3.10/`. Thus, installing
+located at `/usr/share/docassemble/local3.12/`. Thus, installing
 [Python] packages through Ubuntu's `apt` utility will not actually
 make that [Python] code available to **docassemble**. Before using
 [pip], you need to first change the user to `www-data`, and then
@@ -991,7 +991,7 @@ switch into the appropriate [Python virtual environment].
 
 {% highlight bash %}
 su www-data
-source /usr/share/docassemble/local3.10/bin/activate
+source /usr/share/docassemble/local3.12/bin/activate
 {% endhighlight %}
 
 Note that if you want to install a new version of a [Python] package

--- a/_docs/documents.md
+++ b/_docs/documents.md
@@ -2302,7 +2302,7 @@ interview, see the [`cache documents` feature].
 [`words`]: {{ site.baseurl }}/docs/config.html#words
 [`send_email()`]: {{ site.baseurl }}/docs/functions.html#send_email
 [built-in filters]: https://jinja.palletsprojects.com/en/2.11.x/templates/#filters
-[Python built-in functions]: https://docs.python.org/3.10/library/functions.html
+[Python built-in functions]: https://docs.python.org/3.12/library/functions.html
 [filters]: https://jinja.palletsprojects.com/en/2.11.x/templates/#filters
 [tests]: https://jinja.palletsprojects.com/en/2.11.x/templates/#list-of-builtin-tests
 [`DALazyTemplate`]: {{ site.baseurl }}/docs/objects.html#DALazyTemplate

--- a/_docs/errors.md
+++ b/_docs/errors.md
@@ -182,7 +182,7 @@ out the problem.
 [Flask]: https://flask.pocoo.org/
 [WSGI]: https://en.wikipedia.org/wiki/Web_Server_Gateway_Interface
 [Mako]: https://www.makotemplates.org/
-[exec]: https://docs.python.org/3.10/library/functions.html#exec
+[exec]: https://docs.python.org/3.12/library/functions.html#exec
 [pickle]: https://docs.python.org/3/library/pickle.html
 [pickleable]: https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled
 [import]: https://docs.python.org/3/tutorial/modules.html

--- a/_docs/fields.md
+++ b/_docs/fields.md
@@ -3814,7 +3814,7 @@ why this needs to be done manually as opposed to automatically:
 [`.strftime()`]: https://docs.python.org/3/library/datetime.html#datetime.time.strftime
 [`continue button label`]: {{ site.baseurl }}/docs/modifiers.html#continue button label
 [`validation_error()`]: {{ site.baseurl }}/docs/functions.html#validation_error
-[`raise`]: https://docs.python.org/3.10/tutorial/errors.html#raising-exceptions
+[`raise`]: https://docs.python.org/3.12/tutorial/errors.html#raising-exceptions
 [`date`]: #date
 [`number`]: #number
 [`.geocode()`]: {{ site.baseurl }}/docs/objects.html#Address.geocode
@@ -3834,7 +3834,7 @@ why this needs to be done manually as opposed to automatically:
 [`objects from file`]: {{ site.baseurl }}/docs/initial.html#objects from file
 [`data`]: {{ site.baseurl }}/docs/initial.html#data
 [`data from code`]: {{ site.baseurl }}/docs/initial.html#data from code
-[lambda function]: https://docs.python.org/3.10/tutorial/controlflow.html#lambda-expressions
+[lambda function]: https://docs.python.org/3.12/tutorial/controlflow.html#lambda-expressions
 [`modules`]: {{ site.baseurl }}/docs/initial.html#modules
 [`imports`]: {{ site.baseurl }}/docs/initial.html#imports
 [accept]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#attr-accept
@@ -3842,9 +3842,9 @@ why this needs to be done manually as opposed to automatically:
 [`default validation messages`]: {{ site.baseurl }}/docs/initial.html#default validation messages
 [screen parts]: {{ site.baseurl }}/docs/questions.html#screen parts
 [Python expression]: https://stackoverflow.com/questions/4782590/what-is-an-expression-in-python
-[list comprehension]: https://docs.python.org/3.10/tutorial/datastructures.html#list-comprehensions
+[list comprehension]: https://docs.python.org/3.12/tutorial/datastructures.html#list-comprehensions
 [`continue button field`]: #continue button field
-[tuples]: https://docs.python.org/3.10/tutorial/datastructures.html#tuples-and-sequences
+[tuples]: https://docs.python.org/3.12/tutorial/datastructures.html#tuples-and-sequences
 [Ajax]: https://en.wikipedia.org/wiki/Ajax_(programming)
 [`url_action_call()`]: {{ site.baseurl }}/docs/functions.html#js_url_action_call
 [JSON]: https://en.wikipedia.org/wiki/JSON
@@ -3866,10 +3866,10 @@ why this needs to be done manually as opposed to automatically:
 [jQuery Validation Plugin]: https://jqueryvalidation.org
 [jQuery.validator.addMethod()]: https://jqueryvalidation.org/jQuery.validator.addMethod/
 [`validation messages`]: #validation messages
-[Python object]: https://docs.python.org/3.10/tutorial/classes.html
+[Python object]: https://docs.python.org/3.12/tutorial/classes.html
 [`features`]: {{ site.baseurl }}/docs/initial.html#features
 [`.object_name()`]: {{ site.baseurl }}/docs/objects.html#DAObject.object_name
-[Python special methods]: https://docs.python.org/3.10/reference/datamodel.html#special-method-names
+[Python special methods]: https://docs.python.org/3.12/reference/datamodel.html#special-method-names
 [`depends on`]: {{ site.baseurl }}/docs/logic.html#depends on
 [`labels above fields`]: {{ site.baseurl }}/docs/initial.html#labels above fields
 [`floating labels`]: {{ site.baseurl }}/docs/initial.html#floating labels

--- a/_docs/functions.md
+++ b/_docs/functions.md
@@ -8984,9 +8984,9 @@ Note that you should only attach a `daPageLoad` listener from a
 [`validate`]: {{ site.baseurl }}/docs/fields.html#validate
 [`wc_side_of_bed.yml`]: https://github.com/jhpyle/docassemble/blob/master/docassemble_demo/docassemble/demo/data/questions/examples/wc_side_of_bed.yml
 [`wc_common.yml`]: https://github.com/jhpyle/docassemble/blob/master/docassemble_demo/docassemble/demo/data/questions/examples/wc_common.yml
-[lambda function]: https://docs.python.org/3.10/tutorial/controlflow.html#lambda-expressions
-[lambda functions]: https://docs.python.org/3.10/tutorial/controlflow.html#lambda-expressions
-[`raise`]: https://docs.python.org/3.10/tutorial/errors.html#raising-exceptions
+[lambda function]: https://docs.python.org/3.12/tutorial/controlflow.html#lambda-expressions
+[lambda functions]: https://docs.python.org/3.12/tutorial/controlflow.html#lambda-expressions
+[`raise`]: https://docs.python.org/3.12/tutorial/errors.html#raising-exceptions
 [`validation code`]: {{ site.baseurl }}/docs/fields.html#validation code
 [Google Sheets API]: https://developers.google.com/sheets/api/
 [`js show if`]: {{ site.baseurl }}/docs/fields.html#js show if
@@ -8994,7 +8994,7 @@ Note that you should only attach a `daPageLoad` listener from a
 [redact_demo.pdf]: https://github.com/jhpyle/docassemble/blob/master/docassemble_demo/docassemble/demo/data/templates/redact_demo.pdf
 [`somefuncs.py`]: https://github.com/jhpyle/docassemble/blob/master/docassemble_demo/docassemble/demo/somefuncs.py
 [`NameError`]: https://docs.python.org/3/library/exceptions.html#exceptions.NameError
-[`try`/`except`]: https://docs.python.org/3.10/tutorial/errors.html#handling-exceptions
+[`try`/`except`]: https://docs.python.org/3.12/tutorial/errors.html#handling-exceptions
 [`redact: False`]: {{ site.baseurl }}/docs/documents.html#redact
 [`forget_result_of()`]: #forget_result_of
 [`re_run_logic()`]: #re_run_logic
@@ -9035,7 +9035,7 @@ Note that you should only attach a `daPageLoad` listener from a
 [`update_locale()`]: #update_locale
 [`datatype: file`]: {{ site.baseurl }}/docs/fields.html#file
 [`datatype: files`]: {{ site.baseurl }}/docs/fields.html#files
-[`locale`]: https://docs.python.org/3.10/library/locale.html
+[`locale`]: https://docs.python.org/3.12/library/locale.html
 [language-specific functions]: #linguistic
 [`docassemble.base.util.update_word_collection()`]: #update_word_collection
 [`add-separators.docx`]: https://github.com/jhpyle/docassemble/blob/master/docassemble_base/docassemble/base/data/templates/add-separators.docx

--- a/_docs/groups.md
+++ b/_docs/groups.md
@@ -1796,9 +1796,9 @@ after it is defined.
 [`basic-questions.yml`]: {{ site.github.repository_url }}/blob/master/docassemble_base/docassemble/base/data/questions/basic-questions.yml
 [`.number()`]: {{ site.baseurl }}/docs/objects.html#DAList.number
 [`.number_gathered()`]: {{ site.baseurl }}/docs/objects.html#DAList.number_gathered
-[Python interpreter]: https://docs.python.org/3.10/tutorial/interpreter.html
-[Python list]: https://docs.python.org/3.10/tutorial/datastructures.html
-[Python lists]: https://docs.python.org/3.10/tutorial/datastructures.html
+[Python interpreter]: https://docs.python.org/3.12/tutorial/interpreter.html
+[Python list]: https://docs.python.org/3.12/tutorial/datastructures.html
+[Python lists]: https://docs.python.org/3.12/tutorial/datastructures.html
 [Python dict]: https://docs.python.org/3/library/stdtypes.html#dict
 [Python set]: https://docs.python.org/3/library/stdtypes.html#set
 [`sorted()` function]: https://docs.python.org/3/library/functions.html#sorted

--- a/_docs/initial.md
+++ b/_docs/initial.md
@@ -2907,7 +2907,7 @@ contained:
 [`table width`]: #table width
 [`features`]: #features
 [document]: {{ site.baseurl }}/docs/documents.html
-[list]: https://docs.python.org/3.10/tutorial/datastructures.html
+[list]: https://docs.python.org/3.12/tutorial/datastructures.html
 [dictionary]: https://docs.python.org/3/library/stdtypes.html#dict
 [set]: https://docs.python.org/3/library/stdtypes.html#set
 [group]: {{ site.baseurl }}/docs/groups.html

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -358,10 +358,10 @@ cd /usr/share/docassemble
 git clone https://github.com/letsencrypt/letsencrypt
 {% endhighlight %}
 
-# <a name="python"></a>Installing Python 3.10
+# <a name="python"></a>Installing Python 3.12
 
 The most recent version of [Python] compatible with **docassemble** is
-Python 3.10. This version of docassemble is available in recent
+Python 3.12. This version of docassemble is available in recent
 versions of Linux distributions. If it isn't available in your
 distribution, you can compile it from source (see
 [https://python.org](https://python.org)).
@@ -388,7 +388,7 @@ which **docassemble** and the [Python virtual environment] will live:
 
 {% highlight bash %}
 sudo mkdir -p /etc/ssl/docassemble \
-   /usr/share/docassemble/local3.10 \
+   /usr/share/docassemble/local3.12 \
    /usr/share/docassemble/certs \
    /usr/share/docassemble/backup \
    /usr/share/docassemble/config \
@@ -404,7 +404,7 @@ sudo chown -R www-data.www-data /var/www
 sudo chown www-data.www-data /var/run/uwsgi
 sudo chown -R www-data.www-data \
    /tmp/docassemble \
-   /usr/share/docassemble/local3.10 \
+   /usr/share/docassemble/local3.12 \
    /usr/share/docassemble/log \
    /usr/share/docassemble/files
 {% endhighlight %}
@@ -456,8 +456,8 @@ and run the following as `www-data` (i.e., first do `sudo su www-data`):
 
 {% highlight bash %}
 cd /tmp
-python3.10 -m venv --copies /usr/share/docassemble/local3.10
-source /usr/share/docassemble/local3.10/bin/activate
+python3.12 -m venv --copies /usr/share/docassemble/local3.12
+source /usr/share/docassemble/local3.12/bin/activate
 pip3 install --upgrade pip
 pip3 install --upgrade \
   3to2 \
@@ -479,11 +479,11 @@ pip3 install --upgrade \
   ./docassemble/docassemble_base \
   ./docassemble/docassemble_demo \
   ./docassemble/docassemble_webapp
-cp ./docassemble/Docker/pip.conf /usr/share/docassemble/local3.10/
+cp ./docassemble/Docker/pip.conf /usr/share/docassemble/local3.12/
 {% endhighlight %}
 
-This will install a Python 3.10 virtual environment at
-`/usr/share/docassemble/local3.10` and install **docassemble** into it.
+This will install a Python 3.12 virtual environment at
+`/usr/share/docassemble/local3.12` and install **docassemble** into it.
 
 The `pip.conf` file is necessary because it enables the use of
 [GitHub] package references in the `setup.py` files of **docassemble**
@@ -560,7 +560,7 @@ and written by the web server:
 {% highlight bash %}
 sudo chown www-data.www-data /usr/share/docassemble/config/config.yml \
   /usr/share/docassemble/webapp/docassemble.wsgi
-sudo chown -R www-data.www-data /usr/share/docassemble/local3.10 \
+sudo chown -R www-data.www-data /usr/share/docassemble/local3.12 \
   /usr/share/docassemble/log /usr/share/docassemble/files
 sudo chmod ogu+r /usr/share/docassemble/config/config.yml
 {% endhighlight %}
@@ -613,7 +613,7 @@ Then set up the database by running the following commands.
 
 {% highlight bash %}
 echo "create role docassemble with login password 'abc123'; create database docassemble owner docassemble;" | sudo -u postgres psql
-sudo -H -u www-data bash -c "source /usr/share/docassemble/local3.10/bin/activate && python -m docassemble.webapp.create_tables"
+sudo -H -u www-data bash -c "source /usr/share/docassemble/local3.12/bin/activate && python -m docassemble.webapp.create_tables"
 {% endhighlight %}
 
 Note that these commands create a "role" in the [PostgreSQL] server
@@ -1494,8 +1494,8 @@ The [Celery] background process looks like this:
 
 {% highlight text %}
  1288 ?        S      0:00 bash /usr/share/docassemble/webapp/run-celery.sh
- 1295 ?        S      0:11 /usr/share/docassemble/local3.10/bin/python3.10 /usr/share/docassemble/local3.10/bin/celery worker -A docassemble.webapp.worker --loglevel=INFO
- 1349 ?        S      0:00 /usr/share/docassemble/local3.10/bin/python3.10 /usr/share/docassemble/local3.10/bin/celery worker -A docassemble.webapp.worker --loglevel=INFO
+ 1295 ?        S      0:11 /usr/share/docassemble/local3.12/bin/python3.12 /usr/share/docassemble/local3.12/bin/celery worker -A docassemble.webapp.worker --loglevel=INFO
+ 1349 ?        S      0:00 /usr/share/docassemble/local3.12/bin/python3.12 /usr/share/docassemble/local3.12/bin/celery worker -A docassemble.webapp.worker --loglevel=INFO
 {% endhighlight %}
 
 The [web sockets] background process looks like this:
@@ -1521,7 +1521,7 @@ about the virtual environment.  You can do this by running the
 following before you run any [Python] commands:
 
 {% highlight bash %}
-source /usr/share/docassemble/local3.10/bin/activate
+source /usr/share/docassemble/local3.12/bin/activate
 {% endhighlight %}
 
 If you encounter any errors, please register an "issue" on the
@@ -1588,7 +1588,7 @@ directory.)
 cd docassemble
 git pull
 sudo su www-data
-source /usr/share/docassemble/local3.10/bin/activate
+source /usr/share/docassemble/local3.12/bin/activate
 pip install --upgrade \
 ./docassemble \
 ./docassemble_base \
@@ -1607,7 +1607,7 @@ following first:
 
 {% highlight bash %}
 sudo su www-data
-source /usr/share/docassemble/local3.10/bin/activate
+source /usr/share/docassemble/local3.12/bin/activate
 pip uninstall docassemble
 pip uninstall docassemble.base
 pip uninstall docassemble.demo
@@ -1620,7 +1620,7 @@ tables or additional columns in tables.  The
 necessary modifications to the tables.
 
 {% highlight bash %}
-sudo -H -u www-data bash -c "source /usr/share/docassemble/local3.10/bin/activate && python -m docassemble.webapp.create_tables"
+sudo -H -u www-data bash -c "source /usr/share/docassemble/local3.12/bin/activate && python -m docassemble.webapp.create_tables"
 {% endhighlight %}
 
 If you get an error in your logs about a missing column and running
@@ -1632,7 +1632,7 @@ You can delete and recreate your database by running the following commands as r
 
 {% highlight bash %}
 echo "drop database docassemble; create database docassemble owner docassemble;" | sudo -u postgres psql
-sudo -H -u www-data bash -c "source /usr/share/docassemble/local3.10/bin/activate && python -m docassemble.webapp.create_tables"
+sudo -H -u www-data bash -c "source /usr/share/docassemble/local3.12/bin/activate && python -m docassemble.webapp.create_tables"
 rm -rf /usr/share/docassemble/files/0*
 {% endhighlight %}
 

--- a/_docs/interviews.md
+++ b/_docs/interviews.md
@@ -1162,7 +1162,7 @@ containing `# use jinja` was encountered.
 [GET]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
 [POST]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
 [`url_args`]: {{ site.baseurl }}/docs/special.html#url_args
-[pickle]: https://docs.python.org/3.10/library/pickle.html
+[pickle]: https://docs.python.org/3.12/library/pickle.html
 [review screens]: {{ site.baseurl }}/docs/fields.html#review
 [Python objects]: https://docs.python.org/3/tutorial/classes.html
 [Google Form]: https://www.google.com/forms/about/

--- a/_docs/language.md
+++ b/_docs/language.md
@@ -612,7 +612,7 @@ docassemble.base.functions.update_language_function('fr', 'currency_symbol', lam
 {% endhighlight %}
 
 [`currency symbol`]: {{ site.baseurl }}/docs/config.html#currency symbol
-[`locale` module]: https://docs.python.org/3.10/library/locale.html
+[`locale` module]: https://docs.python.org/3.12/library/locale.html
 [`initial`]: {{ site.baseurl }}/docs/logic.html#initial
 [`docx template file`]: {{ site.baseurl }}/docs/documents.html#docx template file
 [initial blocks]: {{ site.baseurl }}/docs/initial.html

--- a/_docs/livehelp.md
+++ b/_docs/livehelp.md
@@ -693,7 +693,7 @@ user will not longer see the calling instructions or the phone icon.
 [`datetime.datetime`]: https://docs.python.org/3/library/datetime.html#datetime.datetime
 [Coordinated Universal Time]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [`timezone_list()`]: {{ site.baseurl }}/docs/functions.html#timezone_list
-[`zoneinfo`]: https://docs.python.org/3.10/library/zoneinfo.html
+[`zoneinfo`]: https://docs.python.org/3.12/library/zoneinfo.html
 [WebSocket]: https://en.wikipedia.org/wiki/WebSocket
 [Configuration]: {{ site.baseurl }}/docs/config.html
 [`DAHOSTNAME`]: {{ site.baseurl }}/docs/docker.html#DAHOSTNAME

--- a/_docs/markup.md
+++ b/_docs/markup.md
@@ -612,8 +612,8 @@ information about this feature, see the section on
 [`video`]: {{ site.baseurl }}/docs/modifiers.html#video
 [`qr_code()`]: {{ site.baseurl }}/docs/functions.html#qr_code
 [code block]: https://daringfireball.net/projects/markdown/syntax#precode
-[Python's `if` statement]: https://docs.python.org/3.10/tutorial/controlflow.html#if-statements
-[Python's `for` statement]: https://docs.python.org/3.10/tutorial/controlflow.html#for-statements
+[Python's `if` statement]: https://docs.python.org/3.12/tutorial/controlflow.html#if-statements
+[Python's `for` statement]: https://docs.python.org/3.12/tutorial/controlflow.html#for-statements
 [object]: {{ site.baseurl }}/docs/objects.html
 [objects]: {{ site.baseurl }}/docs/objects.html
 [groups]: {{ site.baseurl }}/docs/groups.html

--- a/_docs/objects.md
+++ b/_docs/objects.md
@@ -7331,7 +7331,7 @@ method is similar to the `delete_by_id()` class method, except it uses
 the `_uid` of the table rather than the `id`.
 
 [SQL]: https://en.wikipedia.org/wiki/SQL
-[multiple inheritance]: https://docs.python.org/3.10/tutorial/classes.html#multiple-inheritance
+[multiple inheritance]: https://docs.python.org/3.12/tutorial/classes.html#multiple-inheritance
 [Alembic]: https://alembic.sqlalchemy.org/en/latest/front.html
 [custom classes]: #writing
 [SQLAlchemy]: https://www.sqlalchemy.org/
@@ -7501,9 +7501,9 @@ the `_uid` of the table rather than the `id`.
 [Redis]: https://redis.io/
 [in-memory database]: https://en.wikipedia.org/wiki/In-memory_database
 [`redis`]: https://github.com/andymccurdy/redis-py
-[pickling]: https://docs.python.org/3.10/library/pickle.html
-[pickled]: https://docs.python.org/3.10/library/pickle.html
-[pickles]: https://docs.python.org/3.10/library/pickle.html
+[pickling]: https://docs.python.org/3.12/library/pickle.html
+[pickled]: https://docs.python.org/3.12/library/pickle.html
+[pickles]: https://docs.python.org/3.12/library/pickle.html
 [date field]: {{ site.baseurl }}/docs/fields.html#date
 [`birthdate`]: #Individual.birthdate
 [`gender`]: #Individual.gender
@@ -7566,11 +7566,11 @@ the `_uid` of the table rather than the `id`.
 [Object-oriented Programming for Document Assembly Developers]: https://www.nonprofittechy.com/2018/09/12/object-oriented-programming-for-document-assembly-developers/
 [Quinten Steenhuis]: https://www.nonprofittechy.com/about/
 [Python book]: https://shop.oreilly.com/product/0636920028154.do
-[list comprehension]: https://docs.python.org/3.10/tutorial/datastructures.html#list-comprehensions
+[list comprehension]: https://docs.python.org/3.12/tutorial/datastructures.html#list-comprehensions
 [interview session dictionary]: {{ site.baseurl }}/docs/interviews.html#howstored
 [logic]: {{ site.baseurl }}/docs/logic.html
 [interview logic]: {{ site.baseurl }}/docs/logic.html
-[namespace]: https://docs.python.org/3.10/tutorial/classes.html#python-scopes-and-namespaces
+[namespace]: https://docs.python.org/3.12/tutorial/classes.html#python-scopes-and-namespaces
 [write your own functions]: {{ site.baseurl }}/docs/functions.html#yourown
 [`set_alt_text()`]: #DAFile.set_alt_text
 [`get_alt_text()`]: #DAFile.get_alt_text
@@ -7618,8 +7618,8 @@ the `_uid` of the table rather than the `id`.
 [`db`]: {{ site.baseurl }}/docs/config.html#db
 [`DALazyTemplate`]: #DALazyTemplate
 [decorator]: https://realpython.com/primer-on-python-decorators/
-[`Exception`]: https://docs.python.org/3.10/library/exceptions.html#Exception
-[Python OrderedDict]: https://docs.python.org/3.10/library/collections.html#collections.OrderedDict
+[`Exception`]: https://docs.python.org/3.12/library/exceptions.html#Exception
+[Python OrderedDict]: https://docs.python.org/3.12/library/collections.html#collections.OrderedDict
 [Python dict]: https://docs.python.org/3/library/stdtypes.html#dict
 [GET]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
 [POST]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
@@ -7654,11 +7654,11 @@ the `_uid` of the table rather than the `id`.
 [Tesseract]: https://en.wikipedia.org/wiki/Tesseract_(software)
 [Bates numbered]: https://en.wikipedia.org/wiki/Bates_numbering
 [`.reset_geocoding()`]: #Address.reset_geocoding
-[`sorted()`]: https://docs.python.org/3.10/howto/sorting.html
+[`sorted()`]: https://docs.python.org/3.12/howto/sorting.html
 [`reconsider()`]: {{ site.baseurl }}/docs/functions.html#reconsider
 [`force_ask()`]: {{ site.baseurl }}/docs/functions.html#force_ask
 [`invalidate()`]: {{ site.baseurl }}/docs/functions.html#invalidate
-[shallow copy]: https://docs.python.org/3.10/library/copy.html
+[shallow copy]: https://docs.python.org/3.12/library/copy.html
 [`phone_number_is_valid()`]: {{ site.baseurl }}/docs/functions.html#phone_number_is_valid
 [`background_action()`]: {{ site.baseurl }}/docs/background.html#background_action
 [`DAWeb`]: #DAWeb

--- a/_docs/special.md
+++ b/_docs/special.md
@@ -1211,7 +1211,7 @@ internal names include:
 [`run_action_in_session`]: {{ site.baseurl }}/docs/functions.html#run_action_in_session
 [`run_python_module`]: {{ site.baseurl }}/docs/functions.html#run_python_module
 [`selections`]: {{ site.baseurl }}/docs/functions.html#selections
-[`self`]: https://docs.python.org/3.10/tutorial/classes.html
+[`self`]: https://docs.python.org/3.12/tutorial/classes.html
 [`send_email`]: {{ site.baseurl }}/docs/functions.html#send_email
 [`send_fax`]: {{ site.baseurl }}/docs/functions.html#send_fax
 [`send_sms`]: {{ site.baseurl }}/docs/functions.html#send_sms
@@ -1307,7 +1307,7 @@ internal names include:
 [Google Analytics]: https://analytics.google.com
 [`analytics id`]: {{ site.baseurl }}/docs/config.html#google analytics
 [`google`]: {{ site.baseurl }}/docs/config.html#google
-[`re`]: https://docs.python.org/3.10/library/re.html
+[`re`]: https://docs.python.org/3.12/library/re.html
 [`chain`]: https://docs.python.org/3/library/itertools.html#itertools.chain
 [`user_local`]: #user_local
 [`session_local`]: #session_local

--- a/_docs/twotothree.md
+++ b/_docs/twotothree.md
@@ -22,9 +22,11 @@ to `3`.
 
 Starting with [version 0.5.71], **docassemble** ended support for
 Python 2.7 and upgraded to Python 3.6. Starting with [version 1.2.0],
-**docassemble** only supports Python 3.8. In [version 1.4.0] of the
-Docker container, **docassemble** started using Python 3.10, but the
-Python application still supports Python 3.8.
+**docassemble** only supported Python 3.8. In [version 1.4.0] of the
+Docker container, **docassemble** started using Python 3.10 (which
+maintained support for Python 3.8), In [version 1.7.0] of the Docker
+container, **docassemble** started using Python 3.12 and raised the
+minimum supported Python version to 3.9.
 
 If you are currently running a **docassemble** instance on [Docker]
 using Python 2.7, you can upgrade by doing `docker stop`, `docker rm`,
@@ -150,6 +152,7 @@ data.  The following procedure will avoid these problems:
 [version 0.5.70]: https://github.com/jhpyle/docassemble/releases/tag/v0.5.70
 [version 1.2.0]: https://github.com/jhpyle/docassemble/releases/tag/v1.2.0
 [version 1.4.0]: https://github.com/jhpyle/docassemble/releases/tag/v1.4.0
+[version 1.7.0]: https://github.com/jhpyle/docassemble/releases/tag/v1.7.0
 [is no longer maintained]: https://www.python.org/dev/peps/pep-0373/
 [pip]: https://pip.pypa.io/en/stable/
 [`text_type()`]: {{ site.baseurl }}/docs/functions.html#text_type


### PR DESCRIPTION
I updated all of the links to Python documentation, as well as update all of the references for interacting with Python in Docker containers from `3.10` -> `3.12`.

I also expanded the Docassemble/Python version explanation on the `twotothree` page.