### PR TITLE
Don't put extra set of quotes in `pyproject.toml`

### DIFF
--- a/docassemble_webapp/docassemble/webapp/files.py
+++ b/docassemble_webapp/docassemble/webapp/files.py
@@ -613,8 +613,8 @@ def make_package_dir(pkgname, info, author_info, directory=None, current_project
     area = {}
     for sec in ['playground', 'playgroundtemplate', 'playgroundstatic', 'playgroundsources', 'playgroundmodules']:
         area[sec] = SavedFile(author_info['id'], fix=True, section=sec)
-    dependencies_list = [y for y in map(lambda x: repr(get_package_identifier(x)), sorted(info['dependencies'])) if y != "''"]
-    dependencies = ", ".join(dependencies_list)
+    dependencies_list = [y for y in map(lambda x: get_package_identifier(x), sorted(info['dependencies'])) if y != ""]
+    dependencies = ", ".join(map(lambda x: repr(x), dependencies_list))
     licensetext = str(info['license'])
     if re.search(r'MIT', licensetext):
         licensetext += '\n\nCopyright (c) ' + str(datetime.datetime.now().year) + ' ' + str(info.get('author_name', '')) + """


### PR DESCRIPTION
When a `pyproject.toml` is generated from a playground project, an extra set of single quotes inside of the double quotes is included around each dependency. This is because single quotes are used in the `setup.py`, and they are included when generating the dependency string for both.

This PR keeps the pyproject dependency list single quote free, and adds it to the string that gets used in `setup.py`.

For ease of search later on, `pyproject.toml` files generated in this way will have this error when installing:

```
2025-08-11T14:09:46,884   configuration error: `project.dependencies[0]` must be pep508
2025-08-11T14:09:46,884   DESCRIPTION:
2025-08-11T14:09:46,884       Project dependency specification according to PEP 508

2025-08-11T14:09:46,885   GIVEN VALUE:
2025-08-11T14:09:46,885       "'docassemble.ALToolbox>=0.12.0'"

2025-08-11T14:09:46,885   OFFENDING RULE: 'format'

2025-08-11T14:09:46,885   DEFINITION:
2025-08-11T14:09:46,885       {
2025-08-11T14:09:46,885           "$id": "#/definitions/dependency",
2025-08-11T14:09:46,885           "title": "Dependency",
2025-08-11T14:09:46,885           "type": "string",
2025-08-11T14:09:46,885           "format": "pep508"
2025-08-11T14:09:46,885       }

2025-08-11T14:09:46,886   For more details about `format` see
2025-08-11T14:09:46,886   https://validate-pyproject.readthedocs.io/en/latest/api/validate_pyproject.formats.html
```