### PR TITLE
Find both `setup.py` and `pyproject.toml` if both are present

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -10424,7 +10424,7 @@ def get_package_name_from_zip(zippath):
         for zinfo in zf.infolist():
             parts = splitall(zinfo.filename)
             if parts[-1] in ('setup.py', 'pyproject.toml'):
-                if len(parts) < min_level:
+                if len(parts) <= min_level:
                     if parts[-1] == 'setup.py':
                         setup_py = zinfo
                     else:
@@ -21337,8 +21337,8 @@ def api_package():
                         result = docassemble.webapp.worker.update_packages.delay(restart=False)
                     return jsonify_task(result)
                 return jsonify_with_status("You do not have permission to install that package.", 403)
-            except:
-                return jsonify_with_status("There was an error when installing that package.", 400)
+            except Exception as ex:
+                return jsonify_with_status(f"There was an error when installing that package. {ex}", 400)
     return ('File not found', 404)
 
 


### PR DESCRIPTION
Currently, `get_package_name_from_zip` will find whichever of `setup.py` or `pyproject.toml` are at the `min_level` (i.e. closest to the project root). However, due to how the comparison is done, if they are at the same directory level, either one could be found and the other wouldn't be (depending on which one is iterated over first).

Existing projects from [docassemble 1.7](https://github.com/jhpyle/docassemble/blob/484736005270dd6107bf5535dc5dfd1d2e017fab/docassemble_webapp/docassemble/webapp/files.py#L648-L652) have a limited `pyproject.toml` (only the `[build-system]`), and don't include the name of the project. The name is necessary if only `pyproject.toml` is used. The only workaround is to fill in all of the `[project]` section; if just the name is there, `pip` will require all information from `setup.py` to be present.

Pip's exact error message (after adding `[project] name` and `version`):

```
The following seems to be defined outside of `pyproject.toml`:

`dependencies = [...]`

According to the spec (see the link below), however, setuptools CANNOT
consider this value unless `dependencies` is listed as `dynamic`.

https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table

To prevent this problem, you can list `dependencies` under `dynamic` or alternatively
remove the `[project]` table from your file and rely entirely on other means of
configuration.
```

This change (just a `<` to a `<=`) allows both `setup.py` and `pyproject.toml` to be found if both are in the same directory level, and defers to the `setup.py` if it's present (as it's more likely to be complete). This prevents any errors with installing projects that were generated with docassemble 1.7. It also adds the exception message to the `api_package()` response (which is needed to diagnose issues like this).