### PR TITLE
Change 'admin@admin.com' to 'admin@example.com'

### DIFF
--- a/docassemble_webapp/docassemble/webapp/create_tables.py
+++ b/docassemble_webapp/docassemble/webapp/create_tables.py
@@ -124,7 +124,7 @@ def populate_tables(start_time=None):
     result = {}
     admin_defaults = daconfig.get('default admin account', {})
     if 'email' not in admin_defaults:
-        admin_defaults['email'] = os.getenv('DA_ADMIN_EMAIL', 'admin@admin.com')
+        admin_defaults['email'] = os.getenv('DA_ADMIN_EMAIL', 'admin@example.com')
     if 'nickname' not in admin_defaults:
         admin_defaults['nickname'] = 'admin'
     if 'first_name' not in admin_defaults:

--- a/docassemble_webapp/docassemble/webapp/socketserver.py
+++ b/docassemble_webapp/docassemble/webapp/socketserver.py
@@ -397,7 +397,7 @@ def on_interview_disconnect():
 def get_current_info(yaml_filename, session_id, secret):
     url_root = daconfig.get('url root', 'http://localhost') + daconfig.get('root', '/')
     url = url_root + 'interview'
-    return {'user': {'is_anonymous': False, 'is_authenticated': True, 'email': 'admin@admin.com', 'theid': 1, 'the_user_id': 1, 'roles': ['admin'], 'firstname': 'Admin', 'lastname': 'User', 'nickname': '', 'country': '', 'subdivisionfirst': '', 'subdivisionsecond': '', 'subdivisionthird': '', 'organization': '', 'location': None, 'session_uid': 'admin', 'device_id': 'admin'}, 'session': session_id, 'secret': secret, 'yaml_filename': yaml_filename, 'url': url, 'url_root': url_root, 'encrypted': True, 'action': None, 'interface': 'chat', 'arguments': {}}
+    return {'user': {'is_anonymous': False, 'is_authenticated': True, 'email': 'admin@example.com', 'theid': 1, 'the_user_id': 1, 'roles': ['admin'], 'firstname': 'Admin', 'lastname': 'User', 'nickname': '', 'country': '', 'subdivisionfirst': '', 'subdivisionsecond': '', 'subdivisionthird': '', 'organization': '', 'location': None, 'session_uid': 'admin', 'device_id': 'admin'}, 'session': session_id, 'secret': secret, 'yaml_filename': yaml_filename, 'url': url, 'url_root': url_root, 'encrypted': True, 'action': None, 'interface': 'chat', 'arguments': {}}
 
 
 def get_dict(yaml_filename):

--- a/tests/features/TestExamples.feature
+++ b/tests/features/TestExamples.feature
@@ -1059,9 +1059,9 @@ Feature: Example interviews
   Scenario: Test the interview "E-mail address"
     Given I start the interview "docassemble.base:data/questions/examples/email-field.yml"
     Then I should see the phrase "What is your e-mail address?"
-    And I set "E-mail" to "admin@admin.com"
+    And I set "E-mail" to "admin@example.com"
     And I click the button "Continue"
-    Then I should see the phrase "target_variable is: “admin@admin.com”"
+    Then I should see the phrase "target_variable is: “admin@example.com”"
 
   # Scenario: Test the interview "E-mailing the interview"
   #   Given I start the interview "docassemble.base:data/questions/examples/email-to-case-simple.yml"


### PR DESCRIPTION
Realized recently that `admin.com` is a real site. There doesn't seem to be a mail server attached to it, but if the owners decided to make one (or it's compromised), the default admin account would be vulnerable. 

`example.com` is an IANA reserved domain, meaning that it is not available for registration (i.e. no one will ever own it), and are intended for documentation / non-real emails. Switching this to be the default is a slightly safer default for an admin account.

https://www.iana.org/help/example-domains

I have another patch that updates the documentation to match this as well, will open that PR and link it back here.