### PR TITLE
Added Basic Auth for Gotenberg servers

### DIFF
--- a/Docker/config/config.yml.dist
+++ b/Docker/config/config.yml.dist
@@ -141,6 +141,9 @@ sql ping: {{DASQLPING}}
 default icons: font awesome
 config from: {{CONFIGFROM}}
 enable unoconv: {{ENABLEUNOCONV}}
-gotenberg url: {{GOTENBERGURL}}
+gotenberg:
+  url: {{GOTENBERGURL}}
+  username: {{GOTENBERGUSERNAME}}
+  password: {{GOTENBERGPASSWORD}}
 javascript defer: True
 use nginx to serve files: {{USENGINXTOSERVEFILES}}

--- a/Docker/initialize.sh
+++ b/Docker/initialize.sh
@@ -505,6 +505,8 @@ if [ ! -f "$DA_CONFIG_FILE" ]; then
         -e 's/{{DASUPERVISORUSERNAME}}/'"${DASUPERVISORUSERNAME:-null}"'/g' \
         -e 's/{{DASUPERVISORPASSWORD}}/'"${DASUPERVISORPASSWORD:-null}"'/g' \
         -e 's#{{GOTENBERGURL}}#'"${GOTENBERGURL:-null}"'#g' \
+        -e 's#{{GOTENBERGUSERNAME}}#'"${GOTENBERGUSERNAME:-null}"'#g' \
+        -e 's#{{GOTENBERGPASSWORD}}#'"${GOTENBERGPASSWORD:-null}"'#g' \
 	-e 's/{{USENGINXTOSERVEFILES}}/'"${USENGINXTOSERVEFILES:-true}"'/g' \
         "$DA_CONFIG_FILE_DIST" > "$DA_CONFIG_FILE" || exit 1
 fi

--- a/docassemble_base/docassemble/base/config.py
+++ b/docassemble_base/docassemble/base/config.py
@@ -1099,8 +1099,9 @@ def load(**kwargs):
             override_config(daconfig, messages, 'read only file system', 'DAREADONLYFILESYSTEM')
         if env_exists('ENABLEUNOCONV'):
             override_config(daconfig, messages, 'enable unoconv', 'ENABLEUNOCONV')
-        if env_exists('GOTENBERGURL'):
-            override_config(daconfig, messages, 'gotenberg url', 'GOTENBERGURL')
+        for env_var, key in (('GOTENBERGURL', 'url'), ('GOTENBERGUSERNAME', 'username'), ('GOTENBERGPASSWORD', 'password')):
+            if env_exists(env_var):
+                override_config(daconfig, messages, key, env_var, pre_key=['gotenberg'])
         env_messages = messages
     if DEBUG_BOOT:
         boot_log("config: load complete")

--- a/docassemble_base/docassemble/base/pandoc.py
+++ b/docassemble_base/docassemble/base/pandoc.py
@@ -59,9 +59,19 @@ def gotenberg_to_pdf(from_file, to_file, pdfa, password, owner_password):
         data = {'nativePdfFormat': 'PDF/A-1a'}
     else:
         data = {}
-    r = requests.post(daconfig['gotenberg url'] + '/forms/libreoffice/convert', data=data, files={'files': open(from_file, 'rb')}, timeout=6000)
+    url = daconfig.get('gotenberg', {}).get('url', None)
+    if not url:
+        url = daconfig['gotenberg url']
+    gotenberg_username = daconfig.get('gotenberg', {}).get('username', None)
+    gotenberg_password = daconfig.get('gotenberg', {}).get('password', None)
+    if gotenberg_username and gotenberg_password:
+        auth = (gotenberg_username, gotenberg_password)
+    else:
+        auth = None
+    
+    r = requests.post(url + '/forms/libreoffice/convert', auth=auth, data=data, files={'files': open(from_file, 'rb')}, timeout=6000)
     if r.status_code != 200:
-        logmessage("call to " + daconfig['gotenberg url'] + " returned status code " + str(r.status_code))
+        logmessage("call to " + url + " returned status code " + str(r.status_code))
         logmessage(r.text)
         raise DAException("Call to gotenberg did not succeed")
     with open(to_file, 'wb') as fp:
@@ -396,11 +406,12 @@ def word_to_pdf(in_file, in_format, out_file, pdfa=False, password=None, owner_p
     else:
         num_tries = 1
     subprocess_arguments = []
+    gotenberg_enabled = daconfig.get('gotenberg url', None) is not None or daconfig.get('gotenberg',{}).get('url', None) is not None
     while tries < num_tries:
         completed_process = None
         use_libreoffice = True
         if update_refs:
-            if daconfig.get('gotenberg url', None) is not None:
+            if gotenberg_enabled:
                 # update_references(from_file)  # not necessary, since Gotenberg updates references
                 try:
                     gotenberg_to_pdf(from_file, to_file, pdfa, password, owner_password)
@@ -441,7 +452,7 @@ def word_to_pdf(in_file, in_format, out_file, pdfa=False, password=None, owner_p
                     subprocess_arguments = [LIBREOFFICE_PATH, '--headless', '--invisible', 'macro:///Standard.Module1.ConvertToPdf(' + from_file + ',' + to_file + ',True,' + method + ')']
                 else:
                     raise DAException('LibreOffice is not available')
-        elif daconfig.get('gotenberg url', None) is not None:
+        elif gotenberg_enabled:
             try:
                 gotenberg_to_pdf(from_file, to_file, pdfa, password, owner_password)
                 result = 0
@@ -546,7 +557,7 @@ def word_to_pdf(in_file, in_format, out_file, pdfa=False, password=None, owner_p
                     logmessage(f"Didn't get file ({error_msg}), Retrying unoconv with " + repr(subprocess_arguments))
                 else:
                     logmessage(f"Didn't get file ({error_msg}), Retrying libreoffice with " + repr(subprocess_arguments))
-            elif daconfig.get('gotenberg url', None) is not None:
+            elif gotenberg_enabled:
                 logmessage("Retrying gotenberg")
             elif daconfig.get('convertapi secret', None) is not None:
                 logmessage("Retrying convertapi")


### PR DESCRIPTION
Gotenberg added basic auth recently, which is highly encourged when running it on a publically visible URL. https://github.com/gotenberg/gotenberg/issues/684

This change adds `gotenberg: username` and `gotenberg: password` to the config to allow docassembl to call gotenberg servers secured like this. It splits the config to still respect the original `gotenberg url: ...` config or to handle the config being under an attribute, like such.

```yaml
gotenberg:
  url: ...
  username: ...
  password: ...
```

as well as adding the corresponding env vars `GOTENBERGUSERNAME` and `GOTENBERGPASSWORD`.

Tested that the original config works, as well as spinning up a new server with the gotenberg URL.

Writing up documentation for the new config values now as well.