### PR TITLE
Update commands to update docassemble core

### DIFF
--- a/_docs/development.md
+++ b/_docs/development.md
@@ -640,7 +640,7 @@ to install your altered version of the **docassemble** code.  This
 line will install all the packages:
 
 {% highlight bash %}
-pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo ./docassemble
+pip install --no-deps --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo
 {% endhighlight %}
 
 The `--no-deps` and `--no-index` flags speed up the installation
@@ -691,9 +691,9 @@ Here are the contents of `www-compile.sh`:
 #! /bin/bash
 source /etc/profile
 source /usr/share/docassemble/local3.12/bin/activate
-pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo ./docassemble && touch /usr/share/docassemble/webapp/docassemble.wsgi
+pip install --no-deps --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo && touch /usr/share/docassemble/webapp/docassemble.wsgi
 history -s "source /usr/share/docassemble/local3.12/bin/activate"
-history -s "pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo ./docassemble && touch /usr/share/docassemble/webapp/docassemble.wsgi"
+history -s "pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo && touch /usr/share/docassemble/webapp/docassemble.wsgi"
 {% endhighlight %}
 
 When `compile.sh` runs, it will leave you logged in as `www-data` in


### PR DESCRIPTION
* the `docassemble` package is no longer present, so it's not needed in the command.
* The `--no-index` command no longer works, and results in this error: 
    ```
    ERROR: Could not find a version that satisfies the requirement setuptools==80.9.0 (from versions: none)
    ERROR: No matching distribution found for setuptools==80.9.0
    ```
    Running without it allows pip to find setuptools (not sure why it can't find it without the index, as it is installed already).