### PR TITLE
Add Gotenberg PDF/A params that work on Gotenberg 7.10 and newer

### DIFF
--- a/docassemble_base/docassemble/base/pandoc.py
+++ b/docassemble_base/docassemble/base/pandoc.py
@@ -54,15 +54,16 @@ def copy_if_different(source, destination):
         shutil.copyfile(source, destination)
 
 
-def gotenberg_to_pdf(from_file, to_file, pdfa, password, owner_password):
+def gotenberg_to_pdf(from_file, to_file, pdfa, tagged, password, owner_password):
     if pdfa:
         data = {
           'nativePdfFormat': 'PDF/A-1a', # For gotenberg pre-7.10
           'pdfa': 'PDF/A-1b', # For gotenberg post-7.10
-          'pdfua': 'true'
         }
     else:
         data = {}
+    if tagged:
+        data['pdfua'] = True
     url = daconfig['gotenberg']['url']
     gotenberg_username = daconfig['gotenberg'].get('username', None)
     gotenberg_password = daconfig['gotenberg'].get('password', None)
@@ -414,7 +415,7 @@ def word_to_pdf(in_file, in_format, out_file, pdfa=False, password=None, owner_p
             if daconfig['gotenberg']['enable']:
                 # update_references(from_file)  # not necessary, since Gotenberg updates references
                 try:
-                    gotenberg_to_pdf(from_file, to_file, pdfa, password, owner_password)
+                    gotenberg_to_pdf(from_file, to_file, pdfa, tagged, password, owner_password)
                     result = 0
                 except BaseException as err:
                     logmessage("Call to gotenberg failed")
@@ -454,7 +455,7 @@ def word_to_pdf(in_file, in_format, out_file, pdfa=False, password=None, owner_p
                     raise DAException('LibreOffice is not available')
         elif daconfig['gotenberg']['enable']:
             try:
-                gotenberg_to_pdf(from_file, to_file, pdfa, password, owner_password)
+                gotenberg_to_pdf(from_file, to_file, pdfa, tagged, password, owner_password)
                 result = 0
             except BaseException as err:
                 logmessage("Call to gotenberg failed")


### PR DESCRIPTION
Since [version 7.10](https://github.com/gotenberg/gotenberg/releases/tag/v7.10.0), Gotenberg has used the `pdfa` and `pdfua` form params instead of the `nativePdfFormat` to generate PDF/A files. PDFs generated by Gotenberg with the current params are normal, non archive PDFs.

Additionally, [Libreoffice no longer offers PDF/A-1a](https://gotenberg.dev/docs/troubleshooting#pdfa-1a) as a target, as apparently that was always mislabeled and not really conformant. PDF/A-1b is the accepted alternative (there's also PDF/A-2b, but figured sticking with PDF/A-1 was better for backwards compatibility for folks).

This PR adds the new params to the gotenberg call, while leaving in the older param. Docassemble's `pdfa` param maps to the `pdfa` param on Gotenberg, and Docassemble's `tagged` param (now passed to `gotenberg_to_pdf()`) maps to the `pdfua` Gotenberg param. On the newer Gotenberg instances (tested on 8.23), the older params are ignored, and vice-versa on the older gotenberg instances.