### PR TITLE
Add resources for the `.revoke()` background action method

### DIFF
--- a/_docs/background.md
+++ b/_docs/background.md
@@ -184,9 +184,12 @@ called `the_task`.  This variable can be used in the following ways:
       is useful if the task failed because a necessary variable was
       undefined; in that case, the first item in this list will be the
       name of this undefined variable.
-* `the_task.revoke()` will terminate the task. If you only want to
-  remove the task from the queue if it has not started running yet,
-  you can set the optional keyword argument `terminate` to `False`.
+* `the_task.revoke()` will terminate the task. Before using this
+  method read [Celery's documentation about terminating
+  processes](https://docs.celeryq.dev/en/stable/userguide/workers.html#revoke-revoking-tasks:~:text=The%20terminate%20option%20is%20a%20last%20resort)
+  as there are possible pitfalls. If you only want to remove the task
+  from the queue if it has not started running yet, you can set the
+  optional keyword argument `terminate` to `False`.
 
 [Celery] will start trying to run the `bg_task` [action] as soon as
 possible after `background_action()` is called.  If a lot of other


### PR DESCRIPTION
[Terminating Celery processes can have unexpected
  consequences](https://docs.celeryq.dev/en/stable/userguide/workers.html#revoke-revoking-tasks:~:text=The%20terminate%20option%20is%20a%20last%20resort)
  when initiating other processes inside a background action. If I'd understood
  these concepts when considering how to use a background action I would have
  found this information useful.