### PR TITLE
Add support for custom object JSON output

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -5377,6 +5377,8 @@ def safe_json(the_object, level=0, is_key=False):
         return 'None' if is_key else None
     if isinstance(the_object, (str, bool, int, float)):
         return the_object
+    if hasattr(the_object, "to_json") and callable(the_object.to_json):
+        return the_object.to_json()
     if isinstance(the_object, list):
         return [safe_json(x, level=level+1) for x in the_object]
     if isinstance(the_object, dict):


### PR DESCRIPTION
This updates the `safe_json()` function to return the output of the `to_json()` method if one is implemented.

This allows complex objects to define their own JSON output when `docassemble` tries to convert them to JSON. This improves, or even allows at all, complex objects to be displayed using the `all_variables()` function or when the user clicks the `Show variables and values` button on an interview page.