### PR TITLE
Update core development shell scripts

### DIFF
--- a/_docs/development.md
+++ b/_docs/development.md
@@ -643,9 +643,9 @@ line will install all the packages:
 pip install --no-deps --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo
 {% endhighlight %}
 
-The `--no-deps` and `--no-index` flags speed up the installation
-process because they cause `pip` not to go on the internet to update
-all the dependency packages.
+The `--no-deps` flags speed up the installation process because it
+causes `pip` to only install the specified packages and not all of
+their required dependencies.
 
 After you run `pip`, you need to restart the services that use the
 [Python] code.  If you are only going to test your code using the web
@@ -682,7 +682,7 @@ Here are the contents of `compile.sh`:
 
 {% highlight bash %}
 #! /bin/bash
-su -c '/bin/bash --init-file ./www-compile.sh -i' www-data" root
+su --pty -c "/bin/bash --init-file ./www-compile.sh" "www-data"
 {% endhighlight %}
 
 Here are the contents of `www-compile.sh`:
@@ -693,7 +693,7 @@ source /etc/profile
 source /usr/share/docassemble/local3.12/bin/activate
 pip install --no-deps --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo && touch /usr/share/docassemble/webapp/docassemble.wsgi
 history -s "source /usr/share/docassemble/local3.12/bin/activate"
-history -s "pip install --no-deps --no-index --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo && touch /usr/share/docassemble/webapp/docassemble.wsgi"
+history -s "pip install --no-deps --force-reinstall --upgrade ./docassemble_base ./docassemble_webapp ./docassemble_demo && touch /usr/share/docassemble/webapp/docassemble.wsgi"
 {% endhighlight %}
 
 When `compile.sh` runs, it will leave you logged in as `www-data` in


### PR DESCRIPTION
Clarified the usage of the `--no-deps` flag in pip installation instructions and removed the `--no-index` reference. Updated shell command examples for cleanliness in the Ubuntu Docker container.

This PR is based on my recent experience setting up **docassemble** core development.

The current Ubuntu image doesn't use a root password, so I changed the `compile.sh` script to not ask for one. I also added the `--pty` flag to `su` which resolves an error message I got while I had a shell attached to the container (this may depend on what args you pass to Docker). It also makes it so that you can type `exit` to drop out of the `su`; which is handy. I also fixed a typo that had a stray `"`.

The current image also doesn't have `setuptools==80.9.0` installed in the `local3.12` virtual environment, which means that the `www-compile.sh` script history didn't work due to the `--no-index` flag that is there only in the history, not in the actual scripted command. For my development, I downloaded the setuptools wheel (`pip download setuptools==80.9.0`) and adjusted my script to use it (`--find-links=./`), but that feels too fragile to put into the documentation.