### PR TITLE
DADict use self __setitem__ instead of elements __setitem__

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -3285,7 +3285,7 @@ class DADict(DAObject):
         for key, val in kwargs.items():
             new_obj_parameters[key] = val
         newobject = objectFunction(self.instanceName + '[' + repr(entry) + ']', *pargs, **new_obj_parameters)
-        self.elements[entry] = newobject
+        self[entry] = newobject
         self.there_are_any = True
         if objectFunction is None and self.ask_object_type and hasattr(self, 'new_object_type'):
             delattr(self, 'new_object_type')
@@ -3678,7 +3678,7 @@ class DADict(DAObject):
                         parameters_to_use = {}
                     else:
                         raise DAError("new_object_type must be an object type")
-                    self.elements[key] = object_type_to_use(self.instanceName + '[' + repr(key) + ']', **parameters_to_use)
+                    self[key] = object_type_to_use(self.instanceName + '[' + repr(key) + ']', **parameters_to_use)
             if hasattr(self, 'new_object_type'):
                 delattr(self, 'new_object_type')
         for key in keys:
@@ -3769,7 +3769,7 @@ class DADict(DAObject):
             else:
                 self.new_item_name  # pylint: disable=pointless-statement
                 if hasattr(self, 'new_item_value'):
-                    self.elements[self.new_item_name] = self.new_item_value
+                    self[self.new_item_name] = self.new_item_value
                     delattr(self, 'new_item_value')
                     delattr(self, 'new_item_name')
                     if hasattr(self, 'there_is_one_other'):
@@ -3834,7 +3834,7 @@ class DADict(DAObject):
                 var_name = object.__getattribute__(self, 'instanceName') + "[" + repr(index) + "]"
                 raise DAIndexError("name '" + var_name + "' is not defined")
             if self.ask_object_type:
-                self.elements[index] = None
+                self[index] = None
             else:
                 self.initializeObject(index, self.object_type, **self.object_type_parameters)
             return self.elements[index]

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -6942,13 +6942,13 @@ class DAContext(DADict):
         self.pargs = pargs
         self.kwargs = kwargs
         if len(pargs) == 1:
-            self.elements['question'] = pargs[0]
-            self.elements['document'] = pargs[0]
+            self['question'] = pargs[0]
+            self['document'] = pargs[0]
         if len(pargs) >= 2:
-            self.elements['question'] = pargs[0]
-            self.elements['document'] = pargs[1]
+            self['question'] = pargs[0]
+            self['document'] = pargs[1]
         for key, val in kwargs.items():
-            self.elements[key] = val
+            self[key] = val
 
     def __str__(self):
         if isinstance(docassemble.base.functions.this_thread.evaluation_context, str) and docassemble.base.functions.this_thread.evaluation_context.startswith('pandoc'):


### PR DESCRIPTION
Since the default `__setitem__()` method in a `DADict` looks like this:
```
    def __setitem__(self, key, the_value):
        self.elements[key] = the_value
```

I wanted to update all of the methods in a `DADict` to use the class's `self.__setitem__()` via `self[key] =` notation instead of the elements's `self.elements.__setitem__()` via `self.elements[key] =` notation. This would allow me to be able to override only the `__setitem__()` method in my custom `DADict` class (which validates the key before assignment) rather than having to validate the key in a few different places which required additional method overrides.

The method `new()` already does this (`self[parg] = None`), but the method `initializeObject()` does not (`self.elements[entry] = newobject`).