### PR TITLE
Fixed the url generated by `DADict's add_action(url_only=True)` and other `add_action()` improvements

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -4166,7 +4166,7 @@ class DADict(DAObject):
         else:
             message = word(str(message))
         if url_only:
-            return docassemble.base.functions.url_action('_da_dict_add', list=self.instanceName)
+            return docassemble.base.functions.url_action('_da_dict_add', dict=self.instanceName)
         return '<a href="' + docassemble.base.functions.url_action('_da_dict_add', dict=self.instanceName) + '" class="btn' + size + block + ' ' + server.button_class_prefix + color + classname + '">' + icon + str(message) + '</a>'
 
     def _new_elements(self):

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -4125,6 +4125,11 @@ class DADict(DAObject):
             return docassemble.base.functions.url_action('_da_dict_remove', dict=self.instanceName, item=repr(index))
         return output
 
+    def _add_action_button(self, url, classes, icon, the_message):
+        if icon != '':
+            icon = f'<i class="{icon}"></i> '
+        return f'<a href="{url}" class="{classes}">{icon}{the_message}</a>'
+
     def add_action(self, label=None, message=None, url_only=False, icon='plus-circle', color=None, size='sm', block=None, classname=None):  # pylint: disable=redefined-outer-name
         """Returns HTML for adding an item to a dict"""
         if color is None:
@@ -4148,7 +4153,6 @@ class DADict(DAObject):
             icon = re.sub(r'^fas ', 'fa-solid ', icon)
             icon = re.sub(r'^far ', 'fa-regular ', icon)
             icon = re.sub(r'^fab ', 'fa-brands ', icon)
-            icon = '<i class="' + icon + '"></i> '
         else:
             icon = ''
         if classname is None:
@@ -4169,7 +4173,7 @@ class DADict(DAObject):
         the_url = docassemble.base.functions.url_action('_da_dict_add', dict=self.instanceName)
         if url_only:
             return the_url
-        return '<a href="' + the_url + '" class="btn' + size + block + ' ' + server.button_class_prefix + color + classname + '">' + icon + str(message) + '</a>'
+        return self._add_action_button(the_url, 'btn' + size + block + ' ' + server.button_class_prefix + color + ' btn-darevisit' + classname, icon, message)
 
     def _new_elements(self):
         return {}

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -3011,9 +3011,10 @@ class DAList(DAObject):
                 message = word("Add an item")
         else:
             message = word(str(message))
+        the_url = docassemble.base.functions.url_action('_da_list_add', list=self.instanceName)
         if url_only:
-            return docassemble.base.functions.url_action('_da_list_add', list=self.instanceName)
-        return self._add_action_button(docassemble.base.functions.url_action('_da_list_add', list=self.instanceName), 'btn' + size + block + ' ' + server.button_class_prefix + color + ' btn-darevisit' + classname, icon, message)
+            return the_url
+        return self._add_action_button(the_url, 'btn' + size + block + ' ' + server.button_class_prefix + color + ' btn-darevisit' + classname, icon, message)
 
     def hook_on_gather(self, *pargs, **kwargs):
         """Code that runs just before a list is marked as gathered."""
@@ -4165,9 +4166,10 @@ class DADict(DAObject):
                 message = word("Add an item")
         else:
             message = word(str(message))
+        the_url = docassemble.base.functions.url_action('_da_dict_add', dict=self.instanceName)
         if url_only:
-            return docassemble.base.functions.url_action('_da_dict_add', dict=self.instanceName)
-        return '<a href="' + docassemble.base.functions.url_action('_da_dict_add', dict=self.instanceName) + '" class="btn' + size + block + ' ' + server.button_class_prefix + color + classname + '">' + icon + str(message) + '</a>'
+            return the_url
+        return '<a href="' + the_url + '" class="btn' + size + block + ' ' + server.button_class_prefix + color + classname + '">' + icon + str(message) + '</a>'
 
     def _new_elements(self):
         return {}


### PR DESCRIPTION
The url generated by `DADict.add_action(url_only=True)` causes an error because it's the wrong type.

Added `the_url` variable so that the url doesn't have to be written/changed in two places.

DADict: added `_add_action_button()` method and updated `add_action()` method to match DAList implementation