### PR TITLE
Fix complete_elements in DADict/DASet and add cancel_add_or_edit to DADict

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -3690,6 +3690,26 @@ class DADict(DAObject):
             else:
                 str(elem)
 
+    def cancel_add_or_edit(self):
+        unique_id = docassemble.base.functions.this_thread.current_info['user']['session_uid']
+        if 'event_stack' in docassemble.base.functions.this_thread.internal and unique_id in docassemble.base.functions.this_thread.internal['event_stack']:
+            new_stack = []
+            for item in docassemble.base.functions.this_thread.internal['event_stack'][unique_id]:
+                if 'arguments' in item:
+                    if 'dict' in item['arguments'] and item['arguments']['dict'] == self.instanceName:
+                        continue
+                    if 'group' in item['arguments'] and item['arguments']['group'] == self.instanceName:
+                        continue
+                if 'action' in item and item['action'].startswith(self.instanceName + '['):
+                    continue
+                new_stack.append(item)
+            docassemble.base.functions.this_thread.internal['event_stack'][unique_id] = new_stack
+        if self.complete_elements().number() < self.number_gathered():
+            self.popitem()
+        if hasattr(self, 'new_item_name'):
+            delattr(self, 'new_item_name')
+        self.delattr('doing_gathered_and_complete', 'there_is_one_other')
+
     def gathered_and_complete(self):
         """Ensures all items in the dictionary are complete and then returns True."""
         if not hasattr(self, 'doing_gathered_and_complete'):

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -3706,9 +3706,7 @@ class DADict(DAObject):
             docassemble.base.functions.this_thread.internal['event_stack'][unique_id] = new_stack
         if self.complete_elements().number() < self.number_gathered():
             self.popitem()
-        if hasattr(self, 'new_item_name'):
-            delattr(self, 'new_item_name')
-        self.delattr('doing_gathered_and_complete', 'there_is_one_other')
+        self.delattr('doing_gathered_and_complete', 'there_is_one_other', 'new_item_name')
 
     def gathered_and_complete(self):
         """Ensures all items in the dictionary are complete and then returns True."""

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -2541,7 +2541,7 @@ class DAList(DAObject):
             else:
                 try:
                     str(item)
-                except:
+                except Exception:
                     continue
             items.append(item)
         items.gathered = True
@@ -3621,7 +3621,7 @@ class DADict(DAObject):
         """Returns a dictionary containing the key/value pairs that are complete."""
         if complete_attribute is None and hasattr(self, 'complete_attribute'):
             complete_attribute = self.complete_attribute
-        items = {}
+        items = self.__class__(self.instanceName)
         for key, val in self.elements.items():
             if val is None:
                 continue
@@ -3636,9 +3636,10 @@ class DADict(DAObject):
             else:
                 try:
                     str(val)
-                except:
+                except Exception:
                     continue
             items[key] = val
+        items.gathered = True
         return items
 
     def _sorted_keys(self):
@@ -4262,10 +4263,10 @@ class DASet(DAObject):
         return True
 
     def complete_elements(self, complete_attribute=None):
-        """Returns a subset with the elements that are complete."""
+        """Returns a set of the elements that are complete."""
         if complete_attribute is None and hasattr(self, 'complete_attribute'):
             complete_attribute = self.complete_attribute
-        items = set()
+        items = self.__class__(self.instanceName)
         for item in self.elements:
             if item is None:
                 continue
@@ -4280,9 +4281,10 @@ class DASet(DAObject):
             else:
                 try:
                     str(item)
-                except:
+                except Exception:
                     continue
             items.add(item)
+        items.gathered = True
         return items
 
     def filter(self, *pargs, **kwargs):

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -1914,7 +1914,7 @@ class DAList(DAObject):
                     continue
                 new_stack.append(item)
             docassemble.base.functions.this_thread.internal['event_stack'][unique_id] = new_stack
-        if self.complete_elements().number() != self.number_gathered():
+        if self.complete_elements().number() < self.number_gathered():
             self.pop()
         self.delattr('doing_gathered_and_complete', '_necessary_length', 'there_is_one_other')
 


### PR DESCRIPTION
I'm sorry that this PR does more than one thing.

First, it fixes the `complete_elements` methods of `DADict` and `DASet` to return a new instance of their class with the complete_elements, rather than returning a generic `dict` or `set`. This matches the behavior of the method in a `DAList` and gives access to all of the DA methods included expected string output.

Second, it adds the `cancel_add_or_edit` method to `DADict`. This is very similar to the `DAList` version it is based on, but handles deleting the `new_item_name` attribute and uses `popitem` to remove the last item from the dict.

Third, it fixes the logic in `DAList`'s `cancel_add_or_edit` method to only `pop` the last item if `self.complete_elements().number()` is less than `self.number_gathered()` rather than only if they are unequal. This is just a safety net for the (maybe not even possible) edge case where the length of `complete_elements` is somehow bigger than `number_gathered`, in which case you can't know if you want to pop the last element off of the `DAList`. I wrote the `DADict` version using this same logic. In all normal cases this works as expected and the same as with `!=`.