### PR TITLE
Add class method to delete keys from global storage

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -7048,6 +7048,17 @@ class DAGlobal(DAObject):
             globalkey = 'da:daglobal:userid:' + str(this_thread.current_info['user']['the_user_id']) + ':' + str(key)
         return server.server_sql_defined(globalkey)
 
+    @classmethod
+    def delete(cls, base, key):
+        """Deletes the key from the base in the global storage area."""
+        if base == 'interview':
+            globalkey = 'da:daglobal:i:' + str(this_thread.current_info.get('yaml_filename', '')) + ':' + str(key)
+        elif base == 'global':
+            globalkey = 'da:daglobal:global:' + str(key)
+        else:
+            globalkey = 'da:daglobal:userid:' + str(this_thread.current_info['user']['the_user_id']) + ':' + str(key)
+        server.server_sql_delete(globalkey)
+
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         if 'base' not in kwargs:


### PR DESCRIPTION
I think it would be useful for `DAGlobal` to have a class method that can delete keys from the global storage without having to unpack the data first.

In my case it was because I deleted a class that was used by an object stored in a `DAGLobal` key and I didn't have a way to delete it without unpacking it first. This probably won't be useful for 99.9% of users, but it would have saved me having to write it into a `DAGlobal` subclass myself.