### PR TITLE
Bates Numbering customization

### DIFF
--- a/docassemble_base/docassemble/base/bates.py
+++ b/docassemble_base/docassemble/base/bates.py
@@ -7,14 +7,17 @@ parser.add_argument("--prefix", help="prefix for Bates numbers")
 parser.add_argument("--digits", help="number of digits in Bates numbers", type=int)
 parser.add_argument("--start", help="starting number", type=int)
 parser.add_argument("--area", help="area of page")
+parser.add_argument("--offset-horizontal", help="how far to offset the number from the side of the page", type=float)
+parser.add_argument("--offset-vertical", help="how far to offset the number from the side of the page", type=float)
+parser.add_argument("--font-size", help="How big the numbers are", type=float)
 
 
-def bates_number(docs, prefix, digits, start_number, area):
-    m = Marisol(prefix, digits, start_number, area=getattr(Area, area))
+def bates_number(docs, prefix, digits, start_number, area, offset_horizontal, offset_vertical, font_size):
+    m = Marisol(prefix, digits, start_number, area=getattr(Area, area), offset_horizontal=offset_horizontal, offset_vertical=offset_vertical, font_size=font_size)
     for doc in docs:
         m.append(doc)
     m.save()
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    bates_number(args.files, args.prefix, args.digits, args.start, args.area)
+    bates_number(args.files, args.prefix, args.digits, args.start, args.area, args.offset_horizontal, args.offset_vertical, args.font_size)

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -5289,13 +5289,16 @@ class DAFile(DAObject):
         digits = kwargs.get('digits', 5)
         start = kwargs.get('start', 1)
         area = kwargs.get('area', None)
+        font_size = kwargs.get('font_size', 10)
+        offset_horizontal = kwargs.get('offset_horizontal', 15)
+        offset_vertical = kwargs.get('offset_vertical', 15)
         if area is None:
             area = 'BOTTOM_RIGHT'
         if area not in ('TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_RIGHT', 'BOTTOM_LEFT'):
             raise DAError("bates_number: area must be one of TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, or BOTTOM_LEFT")
         if filename is None:
             filename = 'file.pdf'
-        args = [os.path.join(server.daconfig['modules'], 'bin', 'python'), '-m', 'docassemble.base.bates', '--prefix', str(prefix), '--digits', str(digits), '--start', str(start), '--area', area]
+        args = [os.path.join(server.daconfig['modules'], 'bin', 'python'), '-m', 'docassemble.base.bates', '--prefix', str(prefix), '--digits', str(digits), '--start', str(start), '--area', area, '--font-size', str(font_size), '--offset-horizontal', str(offset_horizontal), '--offset-vertical', str(offset_vertical)]
         for doc in docs:
             if isinstance(doc, str):
                 args.append(doc)


### PR DESCRIPTION
Allows for some additional customization of the bates numbering functionality.

Adds three new params to the `bates_number` function: two offsets and font_size.

* `offset_horizontal` is the distance from the left or right edge to the numbers, in PDF space units (default of 1/72th inch)
* `offset_vertical` is the distance from the top or bottom edge to the numbers, in PDF space units (default of 1/72th inch)
* `font_size` is the size of the numbers in points

Does make changes to the vendored `Marisol` library (https://github.com/wikkiewikkie/Marisol), but it's already been modified since being vendored (https://github.com/jhpyle/docassemble/commits/master/docassemble_base/docassemble/base/marisol/marisol.py).