### PR TITLE
Avoid `Object of type DAEmpty is not JSON serializable` error

### DIFF
--- a/docassemble_base/docassemble/base/functions.py
+++ b/docassemble_base/docassemble/base/functions.py
@@ -5418,6 +5418,8 @@ def safe_json(the_object, level=0, is_key=False):
         for sub_object in the_object:
             new_list.append(safe_json(sub_object, level=level+1))
         return new_list
+    if the_object.__class__.__name__ == "DAEmpty":
+        return the_object.to_json()
     if hasattr(the_object, "as_dict") and callable(the_object.as_dict):
         return the_object.as_dict()
     if hasattr(the_object, "to_json") and callable(the_object.to_json):


### PR DESCRIPTION
Due to a slight change in https://github.com/jhpyle/docassemble/commit/0f5b49a58d477249330b461b41157df9f77d6ea1 (not mentioned in the description, so I don't know what the intention was for changing it), `as_dict()` is checked for and called before `to_json()` when `safe_json` is converting objects to JSON serializeable types.

However, when calling `getattr()` on a `DAEmpty`, it will return another `DAEmpty` object. Since `DAEmpty`s are also callable objects that return another `DAEmpty`, calling `as_dict()` first will still leave a `DAEmpty` in the output, which is not safely JSON serializeable, leaving the issues raised in https://github.com/jhpyle/docassemble/pull/877 unfixed.

Adding a special case for DAEmpty to call `to_json()` avoids this issue. Other approaches that could fix the issue include:

* Just moving the `hasattr(the_object, "to_json")...` check before the `as_dict` one. While this is the simplest solution, it adds an implicit assumption in the code that will be easily missed on future refactorings of this function.
* Making sure that the results of calling `as_dict` are still JSON safe. This would cause an infinite recursion on DAEmptys, and either wouldn't fix error or would result in max level nested entries for DAEmptys.
* Add a `as_dict` function to DAEmpty. This would work, but `as_dict` isn't used elsewhere in docassemble code much.