### PR TITLE
Update list collect documentation in groups.md

### DIFF
--- a/_docs/groups.md
+++ b/_docs/groups.md
@@ -1583,7 +1583,7 @@ The available keys for the dictionary are:
   screen.  If it is `Fruit ${ i + 1 },` the items will be labeled
   "Fruit 1," "Fruit 2," etc.
 * `is final`: this can be `True`, `False`, or [Python] code that
-  evaluates to a true or false value.  If the value is true, then the
+  evaluates to a true or false value.  If the value is `False`, then the
   `there_is_another` attribute will be set to `True` when the user
   presses the Continue button.  The default value is `True`.
 * `allow append`: this can be `True`, `False`, or [Python] code that


### PR DESCRIPTION
The documentation says the reverse of how `is final` acts. If `is final` is set to `True`, then the `there_is_another` attribute will be set to False.