### PR TITLE
Fix default errors for `bates_number()`

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -5288,13 +5288,13 @@ class DAFile(DAObject):
         if not all_pdf:
             docs = [pdf_concatenate(docs).path()]
         filename = kwargs.get('filename', None)
-        prefix = kwargs.get('prefix', 'TEST')
-        digits = kwargs.get('digits', 5)
-        start = kwargs.get('start', 1)
-        area = kwargs.get('area', None)
-        font_size = kwargs.get('font_size', None)
-        offset_horizontal = kwargs.get('offset_horizontal', None)
-        offset_vertical = kwargs.get('offset_vertical', None)
+        prefix = kwargs.get('prefix') or 'TEST'
+        digits = kwargs.get('digits') or 5
+        start = kwargs.get('start') or 1
+        area = kwargs.get('area') or None
+        font_size = kwargs.get('font_size') or 10
+        offset_horizontal = kwargs.get('offset_horizontal') or 15
+        offset_vertical = kwargs.get('offset_vertical') or 15
         if area is None:
             area = 'BOTTOM_RIGHT'
         if area not in ('TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_RIGHT', 'BOTTOM_LEFT'):


### PR DESCRIPTION
If any of the `font_size`, `offset_horizontal`, and `offset_vertical` params aren't given, then `bates_number` will error, because the default values for those params are given as `None`, which do not parse into `floats` on the `bates.py` side.

This patch changes the defaults in `util.py` to match the defaults in `marisol.py`: 15 for the offsets and 10 for the font size.

Also changes how the values are retrieved from `kwargs`, to prevent people from breaking the function by passing in `None`s.

Introduced in #898. 

Smallest program that'll fair in 1.9.2.

```yaml
event: done
question: |
  Your document
subquestion: |
  ${ test_document }
---
mandatory: True
code: |
  test_document.bates_number()
  done
---
attachments:
  - variable name: test_document
    filename: test_document
    valid formats: [pdf]
    content: "[BOLDCENTER] A Test Document [BR]"
```

Fails with:

```
bates_number: failure during processing; return value 2 after /usr/share/docassemble/local3.12/bin/python -m docassemble.base.bates --prefix MI- --digits 3 --start 0 --area BOTTOM_LEFT --font-size 5 --offset-horizontal None --offset-vertical 250 /usr/share/docassemble/files/000/000/000/55c/file.pdf
```