### PR TITLE
Fix bug where include_docx_template() spits error when given boolean kwargs

### DIFF
--- a/docassemble_base/docassemble/base/file_docx.py
+++ b/docassemble_base/docassemble/base/file_docx.py
@@ -171,6 +171,8 @@ def include_docx_template(template_file, **kwargs):
     for key, val in kwargs.items():
         if hasattr(val, 'instanceName'):
             the_repr = val.instanceName
+        elif isinstance(val, bool):
+            the_repr = val
         else:
             the_repr = '_codecs.decode(_array.array("b", "' + re.sub(r'\n', '', codecs.encode(bytearray(val, encoding='utf-8'), 'base64').decode()) + '".encode()), "base64").decode()'
         first_paragraph.insert_paragraph_before(str("{%%p set %s = %s %%}" % (key, the_repr)))


### PR DESCRIPTION
Currently, the `include_docx_template()` function returns `TypeError: encoding without a string argument` when given a boolean keyword parameter. 

This commit is fixes that by checking if the keyward parameter is a boolean and, if it is, putting it straight into jinja's `set` command without trying to encode it.