### PR TITLE
Fix issues with the jsonstorage table

### DIFF
--- a/docassemble_webapp/docassemble/webapp/jsonstore.py
+++ b/docassemble_webapp/docassemble/webapp/jsonstore.py
@@ -4,6 +4,7 @@ from docassemble.base.functions import server
 from docassemble.webapp.core.models import JsonStorage as CoreJsonStorage
 import docassemble.webapp.db_object
 from sqlalchemy import Column, Boolean, Integer, String, Text, DateTime, func, create_engine, false, delete, select
+from sqlalchemy.schema import FetchedValue
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.dialects.postgresql.json import JSONB
@@ -26,7 +27,7 @@ else:
 
     class JsonStorage(Base):
         __tablename__ = "jsonstorage"
-        id = Column(Integer(), primary_key=True)
+        id = Column(Integer(), primary_key=True, server_default=FetchedValue())
         filename = Column(String(255), index=True)
         key = Column(String(250), index=True)
         if url.startswith('postgresql'):
@@ -65,23 +66,33 @@ def read_answer_json(user_code, filename, tags=None, all_tags=False):
 
 
 def write_answer_json(user_code, filename, data, tags=None, persistent=False):
-    existing_entry = JsonDb.execute(select(JsonStorage).filter_by(filename=filename, key=user_code, tags=tags).with_for_update()).scalar()
-    if existing_entry:
-        existing_entry.data = data
-        existing_entry.modtime = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-        existing_entry.persistent = persistent
-    else:
-        new_entry = JsonStorage(filename=filename, key=user_code, data=data, tags=tags, persistent=persistent, modtime=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None))
-        JsonDb.add(new_entry)
-    JsonDb.commit()
+    try:
+        existing_entry = JsonDb.execute(select(JsonStorage).filter_by(filename=filename, key=user_code, tags=tags).with_for_update()).scalar()
+        if existing_entry:
+            existing_entry.data = data
+            existing_entry.modtime = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            existing_entry.persistent = persistent
+        else:
+            new_entry = JsonStorage(filename=filename, key=user_code, data=data, tags=tags, persistent=persistent, modtime=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None))
+            JsonDb.add(new_entry)
+    except:
+        JsonDb.rollback()
+        raise
+    finally:
+        JsonDb.commit()
 
 
 def delete_answer_json(user_code, filename, tags=None, delete_all=False, delete_persistent=False):
-    if delete_all:
-        if delete_persistent:
-            JsonDb.execute(delete(JsonStorage).filter_by(filename=filename, key=user_code))
+    try:
+        if delete_all:
+            if delete_persistent:
+                JsonDb.execute(delete(JsonStorage).filter_by(filename=filename, key=user_code))
+            else:
+                JsonDb.execute(delete(JsonStorage).filter_by(filename=filename, key=user_code, persistent=False))
         else:
-            JsonDb.execute(delete(JsonStorage).filter_by(filename=filename, key=user_code, persistent=False))
-    else:
-        JsonDb.execute(delete(JsonStorage).filter_by(filename=filename, key=user_code, tags=tags))
-    JsonDb.commit()
+            JsonDb.execute(delete(JsonStorage).filter_by(filename=filename, key=user_code, tags=tags))
+    except:
+        JsonDb.rollback()
+        raise
+    finally:
+        JsonDb.commit()

--- a/docassemble_webapp/docassemble/webapp/users/models.py
+++ b/docassemble_webapp/docassemble/webapp/users/models.py
@@ -1,3 +1,4 @@
+from sqlalchemy.schema import Index
 from docassemble.webapp.db_object import db, UserMixin
 from docassemble.base.config import dbtableprefix, allowed
 from flask_login import AnonymousUserMixin
@@ -133,7 +134,7 @@ class UserDict(db.Model):
     encrypted = db.Column(db.Boolean(), nullable=False, server_default='1')
     modtime = db.Column(db.DateTime())
 
-db.Index(dbtableprefix + 'ix_userdict_key_filename', UserDict.key, UserDict.filename)
+Index(dbtableprefix + 'ix_userdict_key_filename', UserDict.key, UserDict.filename)
 
 
 class UserDictKeys(db.Model):
@@ -144,7 +145,7 @@ class UserDictKeys(db.Model):
     user_id = db.Column(db.Integer(), db.ForeignKey(dbtableprefix + 'user.id', ondelete='CASCADE'), index=True)
     temp_user_id = db.Column(db.Integer(), db.ForeignKey(dbtableprefix + 'tempuser.id', ondelete='CASCADE'), index=True)
 
-db.Index(dbtableprefix + 'ix_userdictkeys_key_filename', UserDictKeys.key, UserDictKeys.filename)
+Index(dbtableprefix + 'ix_userdictkeys_key_filename', UserDictKeys.key, UserDictKeys.filename)
 
 
 class TempUser(db.Model):


### PR DESCRIPTION
Tried fixing 3 specific things here:

1. Changed `db.Index` to `Index`. The former doesn't work anymore, giving an error `AttributeError: 'Engine' object has no attribute 'Index'`.[^1]
2. We switched our jsonstorage table to an externally hosted SQL database recently and have run into issues in production with 

    > (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "jsonstorage_pkey" DETAIL:  Key (id)=(...) already exists."
    
    This error has happened twice within a week. This shouldn't be happening, but from reading the SQLAlchemy docs it seems that we need to use [`server_default`](https://docs.sqlalchemy.org/en/21/core/defaults.html#marking-implicitly-generated-values-timestamps-and-triggered-columns) to prevent SQL Alchemy from automatically assuming the default of the value? I'm less sure this fix is correct, but it doesn't change current functionality.
3. When we do run into a call that violates the duplicate key, all other writes to the jsonstorage table will fail with

    > This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely) (psycopg2.errors.UniqueViolation) ...
    
    To prevent this from happening, this change catches excepts that occur when writing or deleting from the jsonstorage table and calls `rollback()`.

[^1]: I can't find where this is failing during normal docassemble runs, but the error can be recreated in python.