### PR TITLE
Deduplicate users in shared playground list

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -15366,7 +15366,7 @@ def delete_variable_file(current_project):
 
 def get_list_of_playgrounds():
     user_list = []
-    for user in db.session.execute(select(UserModel.id, UserModel.social_id, UserModel.email, UserModel.first_name, UserModel.last_name).join(UserRoles, UserModel.id == UserRoles.user_id).join(Role, UserRoles.role_id == Role.id).where(and_(UserModel.active == True, or_(Role.name == 'admin', Role.name == 'developer'))).order_by(UserModel.id)):  # noqa: E712 # pylint: disable=singleton-comparison
+    for user in db.session.execute(select(UserModel.id, UserModel.social_id, UserModel.email, UserModel.first_name, UserModel.last_name).join(UserRoles, UserModel.id == UserRoles.user_id).join(Role, UserRoles.role_id == Role.id).where(and_(UserModel.active == True, or_(Role.name == 'admin', Role.name == 'developer'))).distinct().order_by(UserModel.id)):  # noqa: E712 # pylint: disable=singleton-comparison
         if user.social_id.startswith('disabled$'):
             continue
         user_info = {}


### PR DESCRIPTION
Right now, when you use "enter other user's playground", a user with the role administrator *and* developer will appear twice.

This change adds DISTINCT to the shared playground user query so users with both admin and developer roles only appear once