### PR TITLE
Limit translation XLSX reads to A:H

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2355,7 +2355,7 @@ class Question:
                     if not os.path.isfile(the_xlsx_file):
                         raise DAError("The translations file " + the_xlsx_file + " could not be found")
                     import pandas  # pylint: disable=import-outside-toplevel
-                    df = pandas.read_excel(the_xlsx_file)
+                    df = pandas.read_excel(the_xlsx_file, usecols='A:H')
                     for column_name in ('interview', 'question_id', 'index_num', 'hash', 'orig_lang', 'tr_lang', 'orig_text', 'tr_text'):
                         if column_name not in df.columns:
                             raise DAError("Invalid translations file " + os.path.basename(the_xlsx_file) + ": column " + column_name + " is missing")

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -18787,7 +18787,7 @@ def translation_file():
                 if not os.path.isfile(the_xlsx_file):
                     continue
                 import pandas  # pylint: disable=import-outside-toplevel
-                df = pandas.read_excel(the_xlsx_file, na_values=['NaN', '-NaN', '#NA', '#N/A'], keep_default_na=False)
+                df = pandas.read_excel(the_xlsx_file, na_values=['NaN', '-NaN', '#NA', '#N/A'], keep_default_na=False, usecols='A:H')
                 invalid = False
                 for column_name in ('interview', 'question_id', 'index_num', 'hash', 'orig_lang', 'tr_lang', 'orig_text', 'tr_text'):
                     if column_name not in df.columns:


### PR DESCRIPTION
We ran into an issue recently where an author has seemingly added an extra column to the XLSX translation spreadsheet at the max position (16,384) which slowed down their guided interview enough to cause frequent 504 gateway timeouts.

There's no reason for DA to read those columns even if they exist, as the data they contain isn't used. This PR patches docassemble so it only reads in the columns that will be used in the translation system.