### PR TITLE
feat: allow dynamic prevent-going-back conditions

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -795,7 +795,7 @@ class InterviewStatus:
         self.hints = question_result['hints']
         self.helptexts = question_result['helptexts']
         self.extras = question_result['extras']
-        self.can_go_back = question_result['can_go_back']
+        self.can_go_back = question_result.get('can_go_back', self.extras.get('can_go_back', True))
         self.labels = question_result['labels']
         self.sought = question_result['sought']
         self.orig_sought = question_result['orig_sought']

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2486,8 +2486,12 @@ class Question:
         else:
             self.language = self.from_source.get_language()
         if 'prevent going back' in data:
-            if isinstance(data['prevent going back'], (bool, NoneType)):
+            if data['prevent going back'] is None:
+                self.can_go_back = True
+            elif isinstance(data['prevent going back'], bool):
                 self.can_go_back = not data['prevent going back']
+            elif isinstance(data['prevent going back'], str) and not data['prevent going back'].strip():
+                self.can_go_back = True
             else:
                 self.can_go_back = compile('not (' + str(data['prevent going back']) + ')', '<prevent going back>', 'eval')
                 self.find_fields_in(str(data['prevent going back']))

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -795,6 +795,7 @@ class InterviewStatus:
         self.hints = question_result['hints']
         self.helptexts = question_result['helptexts']
         self.extras = question_result['extras']
+        self.can_go_back = question_result['can_go_back']
         self.labels = question_result['labels']
         self.sought = question_result['sought']
         self.orig_sought = question_result['orig_sought']
@@ -2484,8 +2485,12 @@ class Question:
             self.language = data['language']
         else:
             self.language = self.from_source.get_language()
-        if 'prevent going back' in data and data['prevent going back']:
-            self.can_go_back = False
+        if 'prevent going back' in data:
+            if isinstance(data['prevent going back'], (bool, NoneType)):
+                self.can_go_back = not data['prevent going back']
+            else:
+                self.can_go_back = compile('not (' + str(data['prevent going back']) + ')', '<prevent going back>', 'eval')
+                self.find_fields_in(str(data['prevent going back']))
         if 'back button' in data:
             if isinstance(data['back button'], (bool, NoneType)):
                 self.back_button = data['back button']
@@ -5970,6 +5975,10 @@ class Question:
         helptexts = {}
         labels = {}
         extras['required'] = {}
+        if isinstance(self.can_go_back, (bool, NoneType)):
+            extras['can_go_back'] = self.can_go_back
+        else:
+            extras['can_go_back'] = bool(eval(self.can_go_back, user_dict))
         if hasattr(self, 'back_button'):
             if isinstance(self.back_button, (bool, NoneType)):
                 extras['back_button'] = self.back_button
@@ -6860,7 +6869,7 @@ class Question:
         if self.need_post is not None:
             for need_code in self.need_post:
                 eval(need_code, user_dict)
-        return {'type': 'question', 'question_text': question_text, 'subquestion_text': subquestion, 'continue_label': continuelabel, 'audiovideo': audiovideo, 'decorations': decorations, 'help_text': help_text_list, 'interview_help_text': interview_help_text_list, 'attachments': attachment_text, 'question': self, 'selectcompute': selectcompute, 'defaults': defaults, 'hints': hints, 'helptexts': helptexts, 'extras': extras, 'labels': labels, 'sought': sought, 'orig_sought': orig_sought}
+        return {'type': 'question', 'question_text': question_text, 'subquestion_text': subquestion, 'continue_label': continuelabel, 'audiovideo': audiovideo, 'decorations': decorations, 'help_text': help_text_list, 'interview_help_text': interview_help_text_list, 'attachments': attachment_text, 'question': self, 'selectcompute': selectcompute, 'defaults': defaults, 'hints': hints, 'helptexts': helptexts, 'extras': extras, 'can_go_back': extras['can_go_back'], 'labels': labels, 'sought': sought, 'orig_sought': orig_sought}
 
     def processed_attachments(self, the_user_dict, **kwargs):
         use_cache = kwargs.get('use_cache', True)

--- a/docassemble_base/docassemble/base/standardformatter.py
+++ b/docassemble_base/docassemble/base/standardformatter.py
@@ -822,7 +822,7 @@ def as_html(status, debug, root, validation_rules, field_error, the_progress_bar
         datatypes[safeid(status.question.fields_saveas)] = "boolean"
     continue_button_color = status.extras.get('continuecolor', None) or BUTTON_COLOR
     back_button_val = status.extras.get('back_button', None)
-    if (back_button_val or (back_button_val is None and status.question.interview.question_back_button)) and status.question.can_go_back and steps > 1:
+    if (back_button_val or (back_button_val is None and status.question.interview.question_back_button)) and status.can_go_back and steps > 1:
         back_button = '\n                  <button type="button" class="btn ' + BUTTON_STYLE + (status.extras.get('back button color', None) or BUTTON_COLOR_BACK) + ' ' + BUTTON_CLASS + ' daquestionbackbutton danonsubmit" title=' + json.dumps(word("Go back to the previous question")) + '><i class="fa-solid fa-chevron-left me-1"></i>'
         back_button += status.back
         back_button += '</button>'


### PR DESCRIPTION
This PR makes `prevent going back` work like `back button` or other interview keys that evaluate a Python expression for truthiness. It works on one line, or with a scalar.

```
prevent going back: user_has_signed or payment_processed
```
or
```
prevent going back: |
  user_has_signed or payment_processed
```

In my case, I want this added because I want to be able to do this for development so that I can go back, but my users in production can't:
```
prevent going back: not user_has_privilege(["developer", "admin"])
```