### PR TITLE
fix: add action buttons to json output

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -717,6 +717,7 @@ class InterviewStatus:
             for item in self.extras['action_buttons']:
                 new_item = copy.deepcopy(item)
                 new_item['label'] = markdown_to_html(item['label'], trim=True, do_terms=False, status=self, verbatim=not encode)
+                result['additional_buttons'].append(new_item)
                 if debug:
                     output['question'] += '<p>' + new_item['label'] + '</p>'
         if hasattr(self, 'question_text') and getattr(self, 'question_text') is not None:


### PR DESCRIPTION
I was looking into using the API/json output, and realized that `action buttons` weren't being included. Upon investigation, it appears that this was due to a bug where the action buttons were created, but never appended to the `additional_buttons` key.