### PR TITLE
Bump Flask.SocketIO version to 5.6.1

### DIFF
--- a/docassemble_webapp/pyproject.toml
+++ b/docassemble_webapp/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
   "flask-cors==6.0.2",
   "Flask-Login==0.6.3",
   "Flask-Mail==0.10.0",
-  "Flask-SocketIO==5.6.0",
+  "Flask-SocketIO==5.6.1",
   "Flask-SQLAlchemy==3.1.1",
   "Flask-WTF==1.2.2",
   "fonttools==4.61.1",


### PR DESCRIPTION
Needed because 5.6.0 is broken on Flask versions 3.1.2 and up (docassemble is currently using 3.1.3).

An example of the errors that appear in websockets.log

```
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/flask_socketio/__init__.py", line 815, in _handle_event
    ctx.session = session_obj
    ^^^^^^^^^^^
AttributeError: property 'session' of 'RequestContext' object has no setter
```

Full description of what's fixed at https://github.com/miguelgrinberg/Flask-SocketIO/issues/2152.