### PR TITLE
fix: normalized gender comparisons and defaulted to genderless rather than male in salutation and pronoun methods

### DIFF
--- a/docassemble_base/docassemble/base/language/language.py
+++ b/docassemble_base/docassemble/base/language/language.py
@@ -52,6 +52,7 @@ def salutation_default(indiv, **kwargs):
     with_name_and_punctuation = kwargs.get('with_name_and_punctuation', False)
     ensure_definition(indiv, with_name, with_name_and_punctuation)
     used_gender = False
+    gender = str(indiv.gender).casefold()
     if hasattr(indiv, 'salutation_to_use') and indiv.salutation_to_use is not None:
         salut = indiv.salutation_to_use
     elif hasattr(indiv, 'is_doctor') and indiv.is_doctor:
@@ -62,14 +63,17 @@ def salutation_default(indiv, **kwargs):
         salut = 'Dr.'
     elif hasattr(indiv, 'name') and hasattr(indiv.name, 'suffix') and indiv.name.suffix == 'J':
         salut = 'Judge'
-    elif indiv.gender == 'female':
+    elif gender == 'female':
         used_gender = True
         salut = 'Ms.'
-    else:
+    elif gender == 'male':
         used_gender = True
         salut = 'Mr.'
+    else:
+        used_gender = True
+        salut = 'Mx.'
     if with_name_and_punctuation or with_name:
-        if used_gender and indiv.gender not in ('male', 'female'):
+        if used_gender and gender not in ('male', 'female'):
             salut_and_name = indiv.name.full()
         else:
             salut_and_name = salut + ' ' + indiv.name.last

--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -11446,6 +11446,7 @@ class Individual(Person):
             person = '3'
         else:
             person = str(kwargs.pop('person', self.get_point_of_view()))
+        gender = str(self.gender).casefold()
         if person == '2':
             output = your(target, **kwargs)
         elif person == '2p':
@@ -11454,12 +11455,12 @@ class Individual(Person):
             output = my_possessive(target, **kwargs)
         elif person == '1p':
             output = our_possessive(target, **kwargs)
-        elif self.gender == 'female':
+        elif gender == 'female':
             output = her(target, **kwargs)
-        elif self.gender == 'other':
-            output = their(target, **kwargs)
-        else:
+        elif gender == 'male':
             output = his(target, **kwargs)
+        else:
+            output = their(target, **kwargs)
         if 'capitalize' in kwargs and kwargs['capitalize']:
             return capitalize(output)
         return output
@@ -11475,6 +11476,7 @@ class Individual(Person):
             str: Objective pronoun (e.g. ``'you'``, ``'her'``, ``'him'``).
         """
         person = str(kwargs.pop('person', self.get_point_of_view()))
+        gender = str(self.gender).casefold()
         if person == '2':
             output = you_objective(**kwargs)
         elif person == '2p':
@@ -11483,12 +11485,12 @@ class Individual(Person):
             output = me_objective(**kwargs)
         elif person == '1p':
             output = our_objective(**kwargs)
-        elif self.gender == 'female':
+        elif gender == 'female':
             output = her_objective(**kwargs)
-        elif self.gender == 'other':
-            output = genderless_objective(**kwargs)
-        else:
+        elif gender == 'male':
             output = him_objective(**kwargs)
+        else:
+            output = genderless_objective(**kwargs)
         if 'capitalize' in kwargs and kwargs['capitalize']:
             return capitalize(output)
         return output
@@ -11517,6 +11519,7 @@ class Individual(Person):
             person = '3'
         else:
             person = str(kwargs.pop('person', self.get_point_of_view()))
+        gender = str(self.gender).casefold()
         if person == '2':
             output = you_subjective(**kwargs)
         elif person == '2p':
@@ -11525,12 +11528,12 @@ class Individual(Person):
             output = i_subjective(**kwargs)
         elif person == '1p':
             output = we_subjective(**kwargs)
-        elif self.gender == 'female':
+        elif gender == 'female':
             output = she_subjective(**kwargs)
-        elif self.gender == 'other':
-            output = genderless_subjective(**kwargs)
-        else:
+        elif gender == 'male':
             output = he_subjective(**kwargs)
+        else:
+            output = genderless_subjective(**kwargs)
         if 'capitalize' in kwargs and kwargs['capitalize']:
             return capitalize(output)
         return output
@@ -11547,6 +11550,7 @@ class Individual(Person):
                 ``'himself'``).
         """
         person = str(kwargs.pop('person', self.get_point_of_view()))
+        gender = str(self.gender).casefold()
         if person == '2':
             return yourself(**kwargs)
         if person == '2p':
@@ -11555,11 +11559,11 @@ class Individual(Person):
             return myself(**kwargs)
         if person == '1p':
             return ourselves(**kwargs)
-        if self.gender == 'female':
+        if gender == 'female':
             return herself(**kwargs)
-        if self.gender == 'other':
-            return genderless_self(**kwargs)
-        return himself(**kwargs)
+        if gender == 'male':
+            return himself(**kwargs)
+        return genderless_self(**kwargs)
 
     def __setattr__(self, attrname, the_value):
         if attrname == 'name' and isinstance(the_value, str):


### PR DESCRIPTION
This PR normalizes gender comparisons, particularly so that capitalized genders are still handled correctly. If the `gender` attribute is actually an object with a `__str__()` method, then this will actually cause that to work as well by casting the attribute to a string first.

It also changes salutation and the pronoun methods to all default/fall-through to genderless options rather than male options as they were before. I don't actually care that much about this part, I really only want the casefold/lower on the gender attribute comparison, but it seemed weird that if you called `.salutation()` on an `Individual` that had a specific `gender == 'other'` that it would still return `Mr.`, and I did look it up, "Mx." is the genderless salutation.
