### PR TITLE
Add read_packages permission for read-only package access

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -206,6 +206,7 @@ PERMISSIONS_LIST = [
     'interview_data',
     'log_user_in',
     'playground_control',
+    'read_packages',
     'template_parse'
     ]
 
@@ -21447,9 +21448,9 @@ def should_run_create(package_name):
 @csrf.exempt
 @cross_origin(origins='*', methods=['GET', 'POST', 'DELETE', 'HEAD'], automatic_options=True)
 def api_package():
-    if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages']):
-        return jsonify_with_status("Access denied.", 403)
     if request.method == 'GET':
+        if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages', 'read_packages']):
+            return jsonify_with_status("Access denied.", 403)
         package_list, package_auth = get_package_info()  # pylint: disable=unused-variable
         packages = []
         for package in package_list:
@@ -21466,6 +21467,8 @@ def api_package():
                 item['zip_file_number'] = package.package.upload
             packages.append(item)
         return jsonify(packages)
+    if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages']):
+        return jsonify_with_status("Access denied.", 403)
     if request.method == 'DELETE':
         if not app.config['ALLOW_UPDATES']:
             return ('File not found', 404)


### PR DESCRIPTION
Splits the `/api/package` permission check into two separate checks: GET requests only require `read_packages`, while POST and DELETE still require `manage_packages`. Old keys with `manage_packages` still work for GET - no breaking changes.

Also adds `read_packages` to PERMISSIONS_LIST so it can be selected when creating an API key. This allows API keys to be limited to read-only package access, with no permission to install or delete packages