### PR TITLE
Add role="alert" to flashed messages so screen readers announce them

### DIFF
--- a/docassemble_webapp/docassemble/webapp/templates/base_templates/base.html
+++ b/docassemble_webapp/docassemble/webapp/templates/base_templates/base.html
@@ -158,7 +158,7 @@
             {%- if category=='error' %}
               {%- set category='danger' %}
             {%- endif %}
-        <div class="da-alert alert alert-{{category}} alert-dismissible fade show">
+        <div class="da-alert alert alert-{{category}} alert-dismissible fade show" role="alert">
             {{ message|safe }}
           <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ word('Close') }}"></button>
         </div>


### PR DESCRIPTION
## What this fixes

The server-rendered flashed-message banner in `base.html` has no ARIA role, so screen readers do not announce success or error messages.

Concretely: when an interview e-mails its documents, docassemble calls Flask's `flash("Your documents will be e-mailed to ...", 'success')`, which is rendered by this block in `base.html`. A screen reader user presses the button, the page reloads, and they hear nothing to confirm the documents were sent. This matters most for the people docassemble-based tools serve, including blind users filling out court and benefits forms on their own.

## The fix

Add `role="alert"` to the flashed-message `<div>`, matching the JavaScript-injected notification in `config.py` (`NOTIFICATION_MESSAGE`), which already carries `role="alert"`. Both code paths render the same alert markup; this makes the server-rendered one consistent so both are announced. One line, no visible change for sighted users.

Addresses SuffolkLITLab/docassemble#47.
