### PR TITLE
feat: let hide/disable continue button accept a python expression on the same line

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2284,11 +2284,21 @@ class Question:
             else:
                 raise DASourceError("When allowed to set is not a list, it must be plain text." + self.idebug(data))
         if 'hide continue button' in data and 'question' in data:
-            self.hide_continue_button = compile(data['hide continue button'], '<hide continue button>', 'eval')
-            self.find_fields_in(data['hide continue button'])
+            if isinstance(data['hide continue button'], str):
+                data['hide continue button'] = data['hide continue button'].strip()
+                if data['hide continue button'] != '':
+                    self.hide_continue_button = compile(data['hide continue button'], '<hide continue button>', 'eval')
+                    self.find_fields_in(data['hide continue button'])
+            elif data['hide continue button']:
+                self.hide_continue_button = True
         if 'disable continue button' in data and 'question' in data:
-            self.disable_continue_button = compile(data['disable continue button'], '<disable continue button>', 'eval')
-            self.find_fields_in(data['disable continue button'])
+            if isinstance(data['disable continue button'], str):
+                data['disable continue button'] = data['disable continue button'].strip()
+                if data['disable continue button'] != '':
+                    self.disable_continue_button = compile(data['disable continue button'], '<disable continue button>', 'eval')
+                    self.find_fields_in(data['disable continue button'])
+            elif data['disable continue button']:
+                self.disable_continue_button = True
         if 'usedefs' in data:
             defs = []
             if isinstance(data['usedefs'], list):
@@ -5773,7 +5783,11 @@ class Question:
                         raise DAError("allowed to set code did not evaluate to a list of text items")
         for item in ('hide_continue_button', 'disable_continue_button'):
             if hasattr(self, item):
-                extras[item] = bool(eval(getattr(self, item), user_dict))
+                val = getattr(self, item)
+                if isinstance(val, bool):
+                    extras[item] = val
+                else:
+                    extras[item] = bool(eval(val, user_dict))
         if self.reload_after is not None:
             number = str(self.reload_after.text(user_dict))
             if number not in ("False", "false", "Null", "None", "none", "null"):


### PR DESCRIPTION
This is a follow up to https://github.com/jhpyle/docassemble/issues/971

This PR changes the `hide continue button` and `disable continue button` to accept Python expressions on the same line, rather than requiring a scalar (the `|` and the expression to be on a new line). This is the same behavior that my PR https://github.com/jhpyle/docassemble/pull/947 added to `prevent going back` and is consistent with other code in this function.

The only new cases for `hide continue button` and `disable continue button` are:

- Non-string truthy (e.g., `hide continue button: True`): sets `True` directly (previously crashed with `TypeError` in `compile()`)
- Non-string falsey (e.g., `hide continue button: False` or absent): attribute not set, treated as default `False`
- Empty string (e.g., `hide continue button: ''`): stripped to `''`, attribute not set (previously crashed with `SyntaxError` in `compile()`)

All of these new cases prevent a crash/error that could feel unexpected to the user even if they had read the documentation.