### PR TITLE
fix: table's allow reordering

### DIFF
--- a/docassemble_base/docassemble/base/util.py
+++ b/docassemble_base/docassemble/base/util.py
@@ -3723,7 +3723,7 @@ class DAList(DAObject):
             self.hook_after_gather()
 
     def _reorder_buttons(self, classes, index):
-        return '<span class="text-nowrap"><a href="#" role="button" class="' + classes + '" data-tablename="' + myb64quote(self.instanceName) + '" data-tableitem="' + str(index) + '" title=' + json.dumps(word("Reorder by moving up")) + '><i class="fa-solid fa-arrow-up"></i><span class="visually-hidden">' + word("Move up") + '</span></a> <a href="#" role="button" class="btn btn-sm ' + get_button_class_prefix + get_configuration()['button colors'].get('reorder', 'info') + ' btn-darevisit databledown"><i class="fa-solid fa-arrow-down" title=' + json.dumps(word("Reorder by moving down")) + '></i><span class="visually-hidden">' + word("Move down") + '</span></a></span> '
+        return '<span class="text-nowrap"><a href="#" role="button" class="' + classes + '" data-tablename="' + myb64quote(self.instanceName) + '" data-tableitem="' + str(index) + '" title=' + json.dumps(word("Reorder by moving up")) + '><i class="fa-solid fa-arrow-up"></i><span class="visually-hidden">' + word("Move up") + '</span></a> <a href="#" role="button" class="btn btn-sm ' + get_button_class_prefix() + get_configuration()['button colors'].get('reorder', 'info') + ' btn-darevisit databledown"><i class="fa-solid fa-arrow-down" title=' + json.dumps(word("Reorder by moving down")) + '></i><span class="visually-hidden">' + word("Move down") + '</span></a></span> '
 
     def _edit_button(self, url, classes):
         return f'<a href="{url}" role="button" class="{classes}"><span class="text-nowrap"><i class="fa-solid fa-pencil-alt"></i> {word("Edit")}</span></a> '


### PR DESCRIPTION
This PR fixes a bug with the `_reorder_buttons` method of `DAList`: `TypeError: can only concatenate str (not "function") to str`.

Proof of Bug:
```yaml
code: |
  things = DAList("things", object_type=Thing)
  things[0].name.text = "Thing 1"
  things[1].name.text = "Thing 2"
  things.gathered = True
---
table: things.table
rows: things
columns:
  - Name: row_item
allow reordering: True
---
mandatory: True
question: ${ things.table }
```